### PR TITLE
Revert "runner-typeを外部的に指定するようにする"

### DIFF
--- a/.github/workflows/run_full_experiment_with_claude_code_v2.yml
+++ b/.github/workflows/run_full_experiment_with_claude_code_v2.yml
@@ -97,7 +97,7 @@ jobs:
 
   fix-and-rerun:
     name: Fix and Re-run
-    runs-on: ${{ fromJSON(github.event.inputs.runner_type) }}
+    runs-on: ubuntu-latest
     needs: run-experiment
     if: needs.run-experiment.outputs.experiment_passed == 'false'
     timeout-minutes: 60

--- a/.github/workflows/run_trial_experiment_with_claude_code_v2.yml
+++ b/.github/workflows/run_trial_experiment_with_claude_code_v2.yml
@@ -41,7 +41,7 @@ defaults:
 jobs:
   setup:
     name: Setup for Sequential Run
-    runs-on: ${{ fromJSON(github.event.inputs.runner_type) }}
+    runs-on: ubuntu-latest
     outputs:
       current_run_id: ${{ steps.parse.outputs.current_run_id }}
       remaining_run_ids: ${{ steps.parse.outputs.remaining_run_ids }}
@@ -138,7 +138,7 @@ jobs:
     name: Fix and Re-run Trial
     needs: [setup, run-trial-experiment]
     if: needs.setup.outputs.is_empty == 'false' && needs.run-trial-experiment.outputs.experiment_passed == 'false'
-    runs-on: ${{ fromJSON(github.event.inputs.runner_type) }}
+    runs-on: ubuntu-latest
     timeout-minutes: 60
 
     env:


### PR DESCRIPTION
Reverts airas-org/airas-template#6

PRでも指摘していただいたように、gpuを使ったランナーだと失敗してしまうのでrevertした方が良さそうです。