### PR TITLE
feat: materialize figures into images/ at compile time

### DIFF
--- a/.github/workflows/compile_latex.yml
+++ b/.github/workflows/compile_latex.yml
@@ -66,6 +66,21 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
 
+      # Figures live in .research/results/ and .research/diagrams/ and are
+      # materialized into the LaTeX images/ directory at build time (structure
+      # preserved), so no prepare_images_for_latex run or committed copy is
+      # required beforehand. LaTeX references them as images/<relative path>.
+      - name: Materialize figures into the LaTeX images directory
+        run: |
+          mkdir -p "$LATEX_DIR/images"
+          for dir in .research/results .research/diagrams; do
+            if [ -d "$dir" ]; then
+              rsync -am --include='*/' --include='*.pdf' --exclude='*' "$dir/" "$LATEX_DIR/images/"
+            fi
+          done
+          echo "Figures available to LaTeX:"
+          find "$LATEX_DIR/images" -type f | sort || true
+
       - name: Install LaTeX, ChkTeX, and other dependencies
         uses: Wandalen/wretry.action@v3
         with:

--- a/.github/workflows/run_diagram_generator.yml
+++ b/.github/workflows/run_diagram_generator.yml
@@ -15,7 +15,7 @@ on:
       output_dir:
         description: 'Directory to save generated diagrams'
         required: false
-        default: '.research/diagrams'
+        default: '.research/results/diagram'
       github_actions_agent:
         description: 'AI agent tool to use (claude_code or open_code)'
         required: true


### PR DESCRIPTION
## 概要
コンパイルワークフローの冒頭（エージェント実行前）に、`.research/results/` と `.research/diagrams/` 配下の図PDFを `$LATEX_DIR/images/` へ**ディレクトリ構造を保持したまま**実体化するステップを追加します。

## 背景
airas 本体側で図の扱いを「原本は `.research/results/` に一度だけ置き、利用時（コンパイル / Overleaf エクスポート）に実体化する」方式へ変更しています（airas-org/airas#912 のフォローアップ）。これに伴い:

- `push_latex` は `prepare_images_for_latex.yml` をディスパッチしなくなります
- 図はコミットされたコピーではなく、このステップがビルド時に配置します
- LaTeX からの参照は `images/<results からの相対パス>`（例: `images/chart/loss_curve.pdf`）
- 構造保持コピーのため、旧方式（フラット化）で起きえた同名ファイルの上書きが解消されます

`prepare_images_for_latex.yml` 自体は、リリース済みの airas バージョン（push_latex が旧実装）との互換のため残しています。

🤖 Generated with [Claude Code](https://claude.com/claude-code)