### PR TITLE
Add paper reproduction feature

### DIFF
--- a/.github/prompts/run_paper_extraction.md
+++ b/.github/prompts/run_paper_extraction.md
@@ -1,0 +1,26 @@
+You are an independent auditor extracting parameter values from an academic paper, for later
+cross-checking against a separately generated reproduction. This is a standalone task: base every
+value only on what the paper itself states in `REPRO_DIR/paper.txt` (and, if present,
+`REPRO_DIR/tex_src/` — prefer it for exact table numbers and macro definitions).
+
+Task:
+- Read the paper and find the value it states for each parameter name listed under
+  `PARAMETER_KEYS` at the end of this prompt.
+- Write `REPRO_DIR/paper_extraction.json`:
+  ```json
+  {"parameters": [{"name": "learning_rate", "value": "0.01"}]}
+  ```
+- Record a number as digits only (no units, %, commas, or abbreviations like "1.3k"/"1e-6").
+  Record a name (model/dataset/method) as its plain form (e.g. "CIFAR-10", "Adam") without
+  parenthetical qualifiers.
+- Include only the parameters the paper actually states; omit any key it doesn't mention (do not
+  guess or infer a plausible value).
+
+Tool Use:
+- Available tools: Read, Grep, Glob, Write.
+
+Output:
+- Make the file change directly in the workspace. Do not ask for permission; proceed autonomously.
+
+REPRO_DIR:
+PARAMETER_KEYS:

--- a/.github/prompts/run_paper_reproduction.md
+++ b/.github/prompts/run_paper_reproduction.md
@@ -2,10 +2,15 @@ You are an autonomous agent that writes a self-contained reproduction of an acad
 as Hydra-configured code, running in GitHub Actions. You do NOT run the experiment — a separate
 workflow runs it later, agentlessly.
 
+All files for this reproduction live under the directory given as REPRO_DIR (e.g.
+`.reproduction/2407.12345-20260718-153000/`). Never touch the repository-root `src/`, `config/`,
+`requirements.txt`, or `Dockerfile` — those belong to the paper-writing pipeline. Multiple
+reproductions coexist as sibling directories under `.reproduction/`.
+
 Task:
-- Fetch and read the paper, then produce `.reproduction/paper.txt`, `config/config.yaml`,
-  `config/run/reproduction.yaml`, and `src/main.py` at the repository root.
-- `src/main.py` must, when run, perform the experiment and write the figure/table + result.json.
+- Fetch and read the paper, then produce `REPRO_DIR/paper.txt`, `REPRO_DIR/config/config.yaml`,
+  `REPRO_DIR/config/run/reproduction.yaml`, and `REPRO_DIR/src/main.py`.
+- `src/main.py` must, when run from REPRO_DIR, perform the experiment and write the figure/table + result.json.
 
 Core Principle:
 - src/main.py must run the experiment and build the figure/table from the numbers it obtains.
@@ -13,35 +18,35 @@ Core Principle:
 
 Constraints:
 - Do not run git commands against this runner repository (no commit, push, pull, checkout, or branch switch);
-  committing is handled by the workflow. Cloning the paper's implementation repo into .reproduction/repo/ is fine.
-- Do NOT execute src/main.py or create .reproduction/results/ — the run workflow does that.
-- Keep everything runnable on a Linux runner from a fresh venv (declare extra deps in requirements.txt).
+  committing is handled by the workflow. Cloning the paper's implementation repo into REPRO_DIR/repo/ is fine.
+- Do NOT execute src/main.py or create REPRO_DIR/results/ — the run workflow does that.
+- Keep everything runnable on a Linux runner from a fresh venv (declare extra deps in REPRO_DIR/requirements.txt).
 
 Tool Use:
 - Available tools: Bash, Read, Write, Edit, Glob, Grep, WebFetch, WebSearch.
 
-Layout (at the repository root):
-- .reproduction/paper.txt : you create this (transcription of the paper; later validation reads it).
-- .reproduction/repo/      : the implementation repository (already cloned; if missing, WebSearch and clone it).
-- config/config.yaml       : Hydra root config (defaults, results_dir).
-- config/run/reproduction.yaml : the run config holding this reproduction's parameters.
-- src/main.py              : @hydra.main entry point (you write this).
+Layout (all inside REPRO_DIR):
+- REPRO_DIR/paper.txt : you create this (transcription of the paper; later validation reads it).
+- REPRO_DIR/repo/      : the implementation repository (already cloned; if missing, WebSearch and clone it).
+- REPRO_DIR/config/config.yaml       : Hydra root config (defaults, results_dir).
+- REPRO_DIR/config/run/reproduction.yaml : the run config holding this reproduction's parameters.
+- REPRO_DIR/src/main.py              : @hydra.main entry point (you write this).
 
 Understand the Paper (do this first):
-- Fetch PAPER_URL yourself and save a transcription (sections, captions, tables) to `.reproduction/paper.txt`.
+- Fetch PAPER_URL yourself and save a transcription (sections, captions, tables) to `REPRO_DIR/paper.txt`.
 - From the paper and INSTRUCTION, choose exactly one figure or table to reproduce. Prefer an explicit
   figure/table named in INSTRUCTION; otherwise pick the main quantitative result that best supports
   the paper's primary claim. Record your choice (e.g. "Figure 3" / "Table 2") in the summary.
 - Identify exactly which result that figure/table shows: the claim, proposed method vs baselines,
   dataset/metric/conditions, and figure axes/series or table rows/cols.
 - Early exit: if no suitable target can be identified, or the experiment strictly requires a GPU and no
-  CPU substitution works, do NOT write src/main.py. Instead write `.reproduction/results/result.json`
+  CPU substitution works, do NOT write src/main.py. Instead write `REPRO_DIR/results/result.json`
   with `{"error": "target_not_found" | "gpu_required", "summary": "(explanation)"}` and stop.
 - CPU substitution: if allowed, design a qualitative reproduction that runs on CPU (small HF model /
   sklearn / n-gram; a few dozen–hundred examples). Declare it in the config (`source: "substituted"`).
 
 Run Config Generation (Hydra):
-- config/run/reproduction.yaml holds every experiment parameter, named so tuning can override them via
+- REPRO_DIR/config/run/reproduction.yaml holds every experiment parameter, named so tuning can override them via
   Hydra CLI (e.g. `run.learning_rate=0.01`), plus the `optuna` search space for later tuning:
   ```yaml
   run_id: reproduction
@@ -57,21 +62,22 @@ Run Config Generation (Hydra):
       learning_rate: {type: float, low: 0.00001, high: 0.1, log: true}
       batch_size:    {type: categorical, choices: [16, 32, 64, 128]}
   ```
-- config/config.yaml is the Hydra root:
+- REPRO_DIR/config/config.yaml is the Hydra root:
   ```yaml
   defaults:
     - run: reproduction
-  results_dir: .reproduction/results
+  results_dir: results
   ```
 
-Experiment Code (src/main.py):
+Experiment Code (REPRO_DIR/src/main.py):
 - Use `@hydra.main(version_base=None, config_path="../config", config_name="config")`.
 - Read every parameter from `cfg.run.<name>` so Hydra CLI overrides (`run.learning_rate=0.01`) work.
-- Find the experiment code in .reproduction/repo/ (reuse or import from it; implement from the paper if absent).
+- Find the experiment code in REPRO_DIR/repo/ (reuse or import from it; implement from the paper if absent).
 - Run the actual experiment (fix seeds; run under the paper's conditions or the declared substitution).
   For a comparison against baselines, run only the proposed method — never plot/tabulate/transcribe
   baseline numbers into the deliverable.
-- Write deliverables into `cfg.results_dir` (default `.reproduction/results`):
+- Write deliverables into `cfg.results_dir` (default `results`, relative to REPRO_DIR since the run
+  workflow executes with REPRO_DIR as the working directory):
   - figure target → `<results_dir>/repro.png`  (matplotlib: `matplotlib.use("Agg")`).
   - table  target → `<results_dir>/repro.md`   (Markdown table only; proposed method row/col only).
   - always → `<results_dir>/result.json` (schema below).
@@ -101,28 +107,29 @@ result.json Schema (src/main.py writes this at run time, into results_dir):
   (measured by you, never transcribed). For a figure, `note` pinpoints the series/x-value. The
   `optuna.objective` in the config must equal one of these `metrics[].name`.
 
-Required Files:
-- .reproduction/paper.txt
-- config/config.yaml
-- config/run/reproduction.yaml
-- src/main.py
-- requirements.txt  (only if extra packages beyond .reproduction/repo/ are needed)
-- Dockerfile        (optional; see below)
+Required Files (all inside REPRO_DIR):
+- REPRO_DIR/paper.txt
+- REPRO_DIR/config/config.yaml
+- REPRO_DIR/config/run/reproduction.yaml
+- REPRO_DIR/src/main.py
+- REPRO_DIR/requirements.txt  (only if extra packages beyond REPRO_DIR/repo/ are needed)
+- REPRO_DIR/Dockerfile        (optional; see below)
 
 Optional Docker:
-- If you write a Dockerfile at the repository root, the run workflow builds it and runs the experiment
-  inside the container; otherwise it runs natively with uv.
-- The Dockerfile must set `WORKDIR /workspace`, COPY src/ config/ (and .reproduction/repo/ if src/main.py
-  imports it) and requirements.txt, install the dependencies, and leave `python -m src.main` runnable.
-  results_dir (.reproduction/results) is bind-mounted, so write deliverables there as usual.
+- If you write REPRO_DIR/Dockerfile, the run workflow builds it with REPRO_DIR as the build context
+  and runs the experiment inside the container; otherwise it runs natively with uv.
+- The Dockerfile must set `WORKDIR /workspace`, COPY src/ config/ (and repo/ if src/main.py
+  imports it) and requirements.txt (paths relative to REPRO_DIR, the build context), install the
+  dependencies, and leave `python -m src.main` runnable. results_dir (`results`) is bind-mounted,
+  so write deliverables there as usual.
 
 Command Line Interface:
-- The run workflow later executes this (do NOT run it yourself):
-  - native: uv run python -u -m src.main run=reproduction results_dir=.reproduction/results
-  - docker: python -u -m src.main run=reproduction results_dir=.reproduction/results  (inside the container)
+- The run workflow later executes this with REPRO_DIR as the working directory (do NOT run it yourself):
+  - native: uv run python -u -m src.main run=reproduction results_dir=results
+  - docker: python -u -m src.main run=reproduction results_dir=results  (inside the container)
 
 Syntax Validation After Writing:
-- After writing the files, verify syntax only, then fix and re-check any errors:
+- After writing the files, verify syntax only, then fix and re-check any errors (run from REPRO_DIR):
   - Python: `python -c "import ast; ast.parse(open('src/main.py').read())"`
   - YAML:   `python -c "import yaml; yaml.safe_load(open('config/config.yaml')); yaml.safe_load(open('config/run/reproduction.yaml'))"`
 - Never run src/main.py — the run workflow does that.
@@ -138,3 +145,4 @@ Output:
 PAPER_URL:
 INSTRUCTION:
 REPO_URL:
+REPRO_DIR:

--- a/.github/prompts/run_paper_reproduction.md
+++ b/.github/prompts/run_paper_reproduction.md
@@ -26,6 +26,10 @@ Tool Use:
 - Available tools: Bash, Read, Write, Edit, Glob, Grep, WebFetch, WebSearch.
 
 Layout (all inside REPRO_DIR):
+- REPRO_DIR/tex_src/   : arXiv's TeX source, already fetched and extracted for you when the paper is
+                          on arXiv and has one (absent otherwise — a PDF-only submission or non-arXiv
+                          paper). Table numbers and macro definitions are read more accurately from
+                          here than from PDF text, so prefer it over paper.txt when present.
 - REPRO_DIR/paper.txt : you create this (transcription of the paper; later validation reads it).
 - REPRO_DIR/repo/      : the implementation repository (already cloned; if missing, WebSearch and clone it).
 - REPRO_DIR/config/config.yaml       : Hydra root config (defaults, results_dir).
@@ -33,7 +37,9 @@ Layout (all inside REPRO_DIR):
 - REPRO_DIR/src/main.py              : @hydra.main entry point (you write this).
 
 Understand the Paper (do this first):
-- Fetch PAPER_URL yourself and save a transcription (sections, captions, tables) to `REPRO_DIR/paper.txt`.
+- If `REPRO_DIR/tex_src/` exists, Grep/Read it first — it has the paper's exact tables, equations, and
+  macro definitions. Otherwise (or in addition), fetch PAPER_URL yourself. Either way, save a
+  transcription (sections, captions, tables) to `REPRO_DIR/paper.txt`.
 - From the paper and INSTRUCTION, choose exactly one figure or table to reproduce. Prefer an explicit
   figure/table named in INSTRUCTION; otherwise pick the main quantitative result that best supports
   the paper's primary claim. Record your choice (e.g. "Figure 3" / "Table 2") in the summary.
@@ -46,15 +52,30 @@ Understand the Paper (do this first):
   sklearn / n-gram; a few dozen–hundred examples). Declare it in the config (`source: "substituted"`).
 
 Run Config Generation (Hydra):
-- REPRO_DIR/config/run/reproduction.yaml holds every experiment parameter, named so tuning can override them via
-  Hydra CLI (e.g. `run.learning_rate=0.01`), plus the `optuna` search space for later tuning:
+- REPRO_DIR/config/run/reproduction.yaml holds every experiment parameter/condition — not just the
+  ones you plan to tune. Fixed conditions (dataset, model, seed, optimizer, evaluation metric, etc.)
+  belong here too, exactly like tunable hyperparameters; `optuna.search_space` below is only the
+  subset you additionally expose for tuning, named so tuning can override them via Hydra CLI (e.g.
+  `run.learning_rate=0.01`).
+- Annotate every parameter with a `# source: ..., note: ...` comment right where you decide its
+  value, while the paper is freshest in mind. This comment is the only record of `source`/`note`
+  (result.json no longer carries parameters — see below) and is cross-checked against the paper later:
+  - `source`: where the value came from (`paper` / `assumed` / `paper_unspecified` / `substituted`).
+  - `note`: a short justification tied to `source`, not a generic label:
+    - `paper` → cite where in the paper ("same as paper §5.6", "same as paper Table 2").
+    - `substituted` → state the paper's original value and why it was replaced ("paper uses
+      ResNet-50; substituted with ResNet-18 for CPU-only compute").
+    - `assumed` / `paper_unspecified` → say so plainly ("not stated in the paper").
   ```yaml
   run_id: reproduction
-  learning_rate: 0.01
-  batch_size: 64
-  epochs: 10
-  # ... any parameters needed to verify the paper's claim
-  optuna:                 # search space for later hyperparameter tuning
+  dataset: "CIFAR-10"      # source: paper, note: same as paper §4.1
+  model: "ResNet-18"       # source: substituted, note: paper uses ResNet-50; substituted with ResNet-18 for CPU-only compute
+  seed: 42                 # source: assumed, note: not stated in the paper
+  learning_rate: 0.01      # source: paper, note: same as paper §5.6
+  batch_size: 64           # source: paper_unspecified, note: not stated in the paper
+  epochs: 10               # source: paper, note: same as paper Table 2
+  # ... any other parameters needed to verify the paper's claim, each with a source/note comment
+  optuna:                 # search space for later hyperparameter tuning (a subset of the above)
     objective: accuracy   # must equal a metric name written to result.json
     direction: maximize
     n_trials: 20
@@ -90,19 +111,12 @@ result.json Schema (src/main.py writes this at run time, into results_dir):
 {
   "summary": "(Markdown; ## Task / ## Experimental setup / ## Reproduction result)",
   "artifacts": ["repro.png"],
-  "parameters": [
-    {"name": "learning_rate", "value": "0.01", "source": "paper"},
-    {"name": "batch_size", "value": "64", "source": "assumed"}
-  ],
   "metrics": [
     {"name": "accuracy", "value": "82.3", "unit": "%", "role": "proposed",
      "note": "series SGC (proposed), K=5 point"}
   ]
 }
 ```
-- parameters: the conditions actually used (read from cfg), concise snake_case keys matching the config
-  keys. Declare `source` honestly (`paper` / `assumed` / `paper_unspecified` / `substituted`); it is
-  cross-checked against the paper, so do not mislabel a chosen value as `paper`.
 - metrics: measured performance values (matching the deliverable). `role` is `proposed` or `reference`
   (measured by you, never transcribed). For a figure, `note` pinpoints the series/x-value. The
   `optuna.objective` in the config must equal one of these `metrics[].name`.

--- a/.github/prompts/run_paper_reproduction.md
+++ b/.github/prompts/run_paper_reproduction.md
@@ -3,8 +3,8 @@ as Hydra-configured code, running in GitHub Actions. You do NOT run the experime
 workflow runs it later, agentlessly.
 
 Task:
-- Fetch and read the paper, then produce `paper.txt`, `config/config.yaml`, `config/run/reproduction.yaml`,
-  and `src/main.py` under jobs/$RUN_ID/.
+- Fetch and read the paper, then produce `.reproduction/paper.txt`, `config/config.yaml`,
+  `config/run/reproduction.yaml`, and `src/main.py` at the repository root.
 - `src/main.py` must, when run, perform the experiment and write the figure/table + result.json.
 
 Core Principle:
@@ -12,29 +12,31 @@ Core Principle:
 - Never hardcode, mock, or reverse-engineer the paper's known results — the output is audited later.
 
 Constraints:
-- First, run `cd jobs/$RUN_ID` (see RUN_ID at the end). All relative paths are relative to that directory.
 - Do not run git commands against this runner repository (no commit, push, pull, checkout, or branch switch);
-  committing is handled by the workflow. Cloning the paper's implementation repo into repo/ is fine.
-- Do NOT create outputs/ or execute src/main.py — the run workflow does that.
+  committing is handled by the workflow. Cloning the paper's implementation repo into .reproduction/repo/ is fine.
+- Do NOT execute src/main.py or create .reproduction/results/ — the run workflow does that.
 - Keep everything runnable on a Linux runner from a fresh venv (declare extra deps in requirements.txt).
 
 Tool Use:
 - Available tools: Bash, Read, Write, Edit, Glob, Grep, WebFetch, WebSearch.
 
-Directory Layout (under jobs/$RUN_ID/):
-- paper.txt          : you create this (transcription of the paper; later validation reads it).
-- repo/              : the implementation repository (already cloned; if missing, WebSearch and clone it).
-- config/config.yaml : Hydra root config (defaults, results_dir).
-- config/run/reproduction.yaml : the single run config holding this reproduction's parameters.
-- src/main.py        : @hydra.main entry point (you write this).
+Layout (at the repository root):
+- .reproduction/paper.txt : you create this (transcription of the paper; later validation reads it).
+- .reproduction/repo/      : the implementation repository (already cloned; if missing, WebSearch and clone it).
+- config/config.yaml       : Hydra root config (defaults, results_dir).
+- config/run/reproduction.yaml : the run config holding this reproduction's parameters.
+- src/main.py              : @hydra.main entry point (you write this).
 
 Understand the Paper (do this first):
-- Fetch PAPER_URL yourself and save a transcription (sections, captions, tables) to `paper.txt`.
-- Identify exactly which result the target figure/table (TARGET_KIND/TARGET_NUMBER) shows: the claim,
-  proposed method vs baselines, dataset/metric/conditions, and figure axes/series or table rows/cols.
-- Early exit: if the target cannot be identified, or the experiment strictly requires a GPU and no CPU
-  substitution works, do NOT write src/main.py. Instead write `outputs/result.json` with
-  `{"error": "target_not_found" | "gpu_required", "summary": "(explanation)"}` and stop.
+- Fetch PAPER_URL yourself and save a transcription (sections, captions, tables) to `.reproduction/paper.txt`.
+- From the paper and INSTRUCTION, choose exactly one figure or table to reproduce. Prefer an explicit
+  figure/table named in INSTRUCTION; otherwise pick the main quantitative result that best supports
+  the paper's primary claim. Record your choice (e.g. "Figure 3" / "Table 2") in the summary.
+- Identify exactly which result that figure/table shows: the claim, proposed method vs baselines,
+  dataset/metric/conditions, and figure axes/series or table rows/cols.
+- Early exit: if no suitable target can be identified, or the experiment strictly requires a GPU and no
+  CPU substitution works, do NOT write src/main.py. Instead write `.reproduction/results/result.json`
+  with `{"error": "target_not_found" | "gpu_required", "summary": "(explanation)"}` and stop.
 - CPU substitution: if allowed, design a qualitative reproduction that runs on CPU (small HF model /
   sklearn / n-gram; a few dozen–hundred examples). Declare it in the config (`source: "substituted"`).
 
@@ -59,17 +61,17 @@ Run Config Generation (Hydra):
   ```yaml
   defaults:
     - run: reproduction
-  results_dir: outputs
+  results_dir: .reproduction/results
   ```
 
 Experiment Code (src/main.py):
 - Use `@hydra.main(version_base=None, config_path="../config", config_name="config")`.
 - Read every parameter from `cfg.run.<name>` so Hydra CLI overrides (`run.learning_rate=0.01`) work.
-- Find the experiment code in repo/ (reuse or import from it; implement from the paper's equations if absent).
+- Find the experiment code in .reproduction/repo/ (reuse or import from it; implement from the paper if absent).
 - Run the actual experiment (fix seeds; run under the paper's conditions or the declared substitution).
   For a comparison against baselines, run only the proposed method — never plot/tabulate/transcribe
   baseline numbers into the deliverable.
-- Write deliverables into `cfg.results_dir` (default `outputs`):
+- Write deliverables into `cfg.results_dir` (default `.reproduction/results`):
   - figure target → `<results_dir>/repro.png`  (matplotlib: `matplotlib.use("Agg")`).
   - table  target → `<results_dir>/repro.md`   (Markdown table only; proposed method row/col only).
   - always → `<results_dir>/result.json` (schema below).
@@ -99,16 +101,25 @@ result.json Schema (src/main.py writes this at run time, into results_dir):
   (measured by you, never transcribed). For a figure, `note` pinpoints the series/x-value. The
   `optuna.objective` in the config must equal one of these `metrics[].name`.
 
-Required Files (under jobs/$RUN_ID/):
-- paper.txt
+Required Files:
+- .reproduction/paper.txt
 - config/config.yaml
 - config/run/reproduction.yaml
 - src/main.py
-- requirements.txt  (only if extra packages beyond repo/ are needed)
+- requirements.txt  (only if extra packages beyond .reproduction/repo/ are needed)
+- Dockerfile        (optional; see below)
+
+Optional Docker:
+- If you write a Dockerfile at the repository root, the run workflow builds it and runs the experiment
+  inside the container; otherwise it runs natively with uv.
+- The Dockerfile must set `WORKDIR /workspace`, COPY src/ config/ (and .reproduction/repo/ if src/main.py
+  imports it) and requirements.txt, install the dependencies, and leave `python -m src.main` runnable.
+  results_dir (.reproduction/results) is bind-mounted, so write deliverables there as usual.
 
 Command Line Interface:
-- The run workflow later executes exactly this (do NOT run it yourself):
-  - uv run python -u -m src.main run=reproduction results_dir=outputs
+- The run workflow later executes this (do NOT run it yourself):
+  - native: uv run python -u -m src.main run=reproduction results_dir=.reproduction/results
+  - docker: python -u -m src.main run=reproduction results_dir=.reproduction/results  (inside the container)
 
 Syntax Validation After Writing:
 - After writing the files, verify syntax only, then fix and re-check any errors:
@@ -122,11 +133,8 @@ Principles:
 - A qualitative reproduction is the goal, not an exact numeric match; record discrepancies honestly.
 
 Output:
-- Make all file changes directly under jobs/$RUN_ID/. Do not ask for permission; proceed autonomously.
+- Make all file changes directly in the workspace. Do not ask for permission; proceed autonomously.
 
-RUN_ID:
 PAPER_URL:
 INSTRUCTION:
-TARGET_KIND:
-TARGET_NUMBER:
 REPO_URL:

--- a/.github/prompts/run_paper_reproduction.md
+++ b/.github/prompts/run_paper_reproduction.md
@@ -1,0 +1,132 @@
+You are an autonomous agent that writes a self-contained reproduction of an academic paper's experiment
+as Hydra-configured code, running in GitHub Actions. You do NOT run the experiment — a separate
+workflow runs it later, agentlessly.
+
+Task:
+- Fetch and read the paper, then produce `paper.txt`, `config/config.yaml`, `config/run/reproduction.yaml`,
+  and `src/main.py` under jobs/$RUN_ID/.
+- `src/main.py` must, when run, perform the experiment and write the figure/table + result.json.
+
+Core Principle:
+- src/main.py must run the experiment and build the figure/table from the numbers it obtains.
+- Never hardcode, mock, or reverse-engineer the paper's known results — the output is audited later.
+
+Constraints:
+- First, run `cd jobs/$RUN_ID` (see RUN_ID at the end). All relative paths are relative to that directory.
+- Do not run git commands against this runner repository (no commit, push, pull, checkout, or branch switch);
+  committing is handled by the workflow. Cloning the paper's implementation repo into repo/ is fine.
+- Do NOT create outputs/ or execute src/main.py — the run workflow does that.
+- Keep everything runnable on a Linux runner from a fresh venv (declare extra deps in requirements.txt).
+
+Tool Use:
+- Available tools: Bash, Read, Write, Edit, Glob, Grep, WebFetch, WebSearch.
+
+Directory Layout (under jobs/$RUN_ID/):
+- paper.txt          : you create this (transcription of the paper; later validation reads it).
+- repo/              : the implementation repository (already cloned; if missing, WebSearch and clone it).
+- config/config.yaml : Hydra root config (defaults, results_dir).
+- config/run/reproduction.yaml : the single run config holding this reproduction's parameters.
+- src/main.py        : @hydra.main entry point (you write this).
+
+Understand the Paper (do this first):
+- Fetch PAPER_URL yourself and save a transcription (sections, captions, tables) to `paper.txt`.
+- Identify exactly which result the target figure/table (TARGET_KIND/TARGET_NUMBER) shows: the claim,
+  proposed method vs baselines, dataset/metric/conditions, and figure axes/series or table rows/cols.
+- Early exit: if the target cannot be identified, or the experiment strictly requires a GPU and no CPU
+  substitution works, do NOT write src/main.py. Instead write `outputs/result.json` with
+  `{"error": "target_not_found" | "gpu_required", "summary": "(explanation)"}` and stop.
+- CPU substitution: if allowed, design a qualitative reproduction that runs on CPU (small HF model /
+  sklearn / n-gram; a few dozen–hundred examples). Declare it in the config (`source: "substituted"`).
+
+Run Config Generation (Hydra):
+- config/run/reproduction.yaml holds every experiment parameter, named so tuning can override them via
+  Hydra CLI (e.g. `run.learning_rate=0.01`), plus the `optuna` search space for later tuning:
+  ```yaml
+  run_id: reproduction
+  learning_rate: 0.01
+  batch_size: 64
+  epochs: 10
+  # ... any parameters needed to verify the paper's claim
+  optuna:                 # search space for later hyperparameter tuning
+    objective: accuracy   # must equal a metric name written to result.json
+    direction: maximize
+    n_trials: 20
+    search_space:
+      learning_rate: {type: float, low: 0.00001, high: 0.1, log: true}
+      batch_size:    {type: categorical, choices: [16, 32, 64, 128]}
+  ```
+- config/config.yaml is the Hydra root:
+  ```yaml
+  defaults:
+    - run: reproduction
+  results_dir: outputs
+  ```
+
+Experiment Code (src/main.py):
+- Use `@hydra.main(version_base=None, config_path="../config", config_name="config")`.
+- Read every parameter from `cfg.run.<name>` so Hydra CLI overrides (`run.learning_rate=0.01`) work.
+- Find the experiment code in repo/ (reuse or import from it; implement from the paper's equations if absent).
+- Run the actual experiment (fix seeds; run under the paper's conditions or the declared substitution).
+  For a comparison against baselines, run only the proposed method — never plot/tabulate/transcribe
+  baseline numbers into the deliverable.
+- Write deliverables into `cfg.results_dir` (default `outputs`):
+  - figure target → `<results_dir>/repro.png`  (matplotlib: `matplotlib.use("Agg")`).
+  - table  target → `<results_dir>/repro.md`   (Markdown table only; proposed method row/col only).
+  - always → `<results_dir>/result.json` (schema below).
+- Hydra does not chdir by default (version_base=None); resolve `cfg.results_dir` relative to the original cwd.
+- src/main.py must never reverse-engineer parameters from the paper's numbers, hardcode/mock results, or
+  transcribe un-run baseline values into the deliverable.
+
+result.json Schema (src/main.py writes this at run time, into results_dir):
+```json
+{
+  "summary": "(Markdown; ## Task / ## Experimental setup / ## Reproduction result)",
+  "artifacts": ["repro.png"],
+  "parameters": [
+    {"name": "learning_rate", "value": "0.01", "source": "paper"},
+    {"name": "batch_size", "value": "64", "source": "assumed"}
+  ],
+  "metrics": [
+    {"name": "accuracy", "value": "82.3", "unit": "%", "role": "proposed",
+     "note": "series SGC (proposed), K=5 point"}
+  ]
+}
+```
+- parameters: the conditions actually used (read from cfg), concise snake_case keys matching the config
+  keys. Declare `source` honestly (`paper` / `assumed` / `paper_unspecified` / `substituted`); it is
+  cross-checked against the paper, so do not mislabel a chosen value as `paper`.
+- metrics: measured performance values (matching the deliverable). `role` is `proposed` or `reference`
+  (measured by you, never transcribed). For a figure, `note` pinpoints the series/x-value. The
+  `optuna.objective` in the config must equal one of these `metrics[].name`.
+
+Required Files (under jobs/$RUN_ID/):
+- paper.txt
+- config/config.yaml
+- config/run/reproduction.yaml
+- src/main.py
+- requirements.txt  (only if extra packages beyond repo/ are needed)
+
+Command Line Interface:
+- The run workflow later executes exactly this (do NOT run it yourself):
+  - uv run python -u -m src.main run=reproduction results_dir=outputs
+
+Syntax Validation After Writing:
+- After writing the files, verify syntax only, then fix and re-check any errors:
+  - Python: `python -c "import ast; ast.parse(open('src/main.py').read())"`
+  - YAML:   `python -c "import yaml; yaml.safe_load(open('config/config.yaml')); yaml.safe_load(open('config/run/reproduction.yaml'))"`
+- Never run src/main.py — the run workflow does that.
+
+Principles:
+- You write and verify the code by reading/reasoning — you do NOT execute it here.
+- Parameters live only in the Hydra config; src/main.py reads them via cfg so tuning can override them.
+- A qualitative reproduction is the goal, not an exact numeric match; record discrepancies honestly.
+
+Output:
+- Make all file changes directly under jobs/$RUN_ID/. Do not ask for permission; proceed autonomously.
+
+RUN_ID:
+PAPER_URL:
+INSTRUCTION:
+TARGET_KIND:
+TARGET_NUMBER:
+REPO_URL:

--- a/.github/scripts/paper_reproduction/extract_config_keys.py
+++ b/.github/scripts/paper_reproduction/extract_config_keys.py
@@ -1,0 +1,43 @@
+"""Extract the parameter key schema from the generated Hydra run config.
+
+Used to hand the paper-extraction agent (run after the code-generation agent) a fixed list
+of parameter names to look up in the paper, without exposing it to the actual config values
+(run_id/optuna are excluded — they aren't paper-reportable experiment parameters).
+
+Usage:
+  python3 extract_config_keys.py --config <REPRO_DIR>/config/run/reproduction.yaml
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+import yaml
+
+_EXCLUDED_KEYS = {"run_id", "optuna"}
+
+
+def extract_keys(config_path: Path) -> list[str]:
+    data = yaml.safe_load(config_path.read_text())
+    if not isinstance(data, dict):
+        return []
+    return [k for k in data if k not in _EXCLUDED_KEYS]
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--config", required=True, type=Path)
+    args = parser.parse_args()
+
+    if not args.config.is_file():
+        print(f"::error::Config file not found: {args.config}", file=sys.stderr)
+        raise SystemExit(1)
+
+    for key in extract_keys(args.config):
+        print(key)
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/scripts/paper_reproduction/fetch_arxiv_tex_source.py
+++ b/.github/scripts/paper_reproduction/fetch_arxiv_tex_source.py
@@ -1,0 +1,86 @@
+"""Fetch an arXiv paper's TeX source tarball and extract it to REPRO_DIR/tex_src/.
+
+Table numbers and macro definitions are read more accurately from the TeX source than
+from PDF text extraction, so the generation agent is told to prefer tex_src/ when present
+(see run_paper_reproduction.md). This is a no-op for non-arXiv URLs, or when arXiv has no
+TeX source for this paper (PDF-only submission) — in both cases the agent falls back to
+fetching the paper itself.
+
+Usage:
+  python3 fetch_arxiv_tex_source.py --paper-url <url> --repro-dir .reproduction/<repro_id>
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import tarfile
+import urllib.request
+from io import BytesIO
+from pathlib import Path
+
+_ARXIV_ID_RE = re.compile(r"arxiv\.org/(?:abs|pdf|src)/([0-9v.]+)")
+_REQUEST_TIMEOUT_SECONDS = 120
+
+
+def parse_arxiv_id(url: str) -> str | None:
+    m = _ARXIV_ID_RE.search(url)
+    return m.group(1) if m else None
+
+
+def _extract_tex_files(tar: tarfile.TarFile, tex_dir: Path) -> int:
+    extracted = 0
+    for member in tar.getmembers():
+        if not member.isfile() or not member.name.lower().endswith(".tex"):
+            continue
+        f = tar.extractfile(member)
+        if f is None:
+            continue
+        # arXiv tarballs sometimes wrap everything in a single top-level directory;
+        # strip it so tex_src/ holds the sources directly.
+        parts = Path(member.name).parts
+        rel = Path(*parts[1:]) if len(parts) > 1 else Path(parts[0])
+        dest = tex_dir / rel
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        dest.write_bytes(f.read())
+        extracted += 1
+    return extracted
+
+
+def fetch_tex_source(arxiv_id: str, repro_dir: Path) -> None:
+    src_url = f"https://arxiv.org/src/{arxiv_id}"
+    with urllib.request.urlopen(src_url, timeout=_REQUEST_TIMEOUT_SECONDS) as resp:
+        data = resp.read()
+
+    if data.startswith(b"%PDF"):
+        print(f"arXiv {arxiv_id} has no TeX source (PDF-only submission); skipping.")
+        return
+
+    tex_dir = repro_dir / "tex_src"
+    with tarfile.open(fileobj=BytesIO(data)) as tar:
+        extracted = _extract_tex_files(tar, tex_dir)
+    if extracted:
+        print(f"Extracted {extracted} .tex file(s) to {tex_dir}")
+    else:
+        print(f"No .tex files found in the arXiv source tarball for {arxiv_id}")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--paper-url", required=True)
+    parser.add_argument("--repro-dir", required=True, type=Path)
+    args = parser.parse_args()
+
+    arxiv_id = parse_arxiv_id(args.paper_url)
+    if not arxiv_id:
+        print("Not an arXiv URL; skipping TeX source fetch.")
+        return
+
+    try:
+        fetch_tex_source(arxiv_id, args.repro_dir)
+    except Exception as exc:
+        print(f"::warning::Failed to fetch arXiv TeX source for {arxiv_id}: {exc}")
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/scripts/paper_reproduction/tune_driver.py
+++ b/.github/scripts/paper_reproduction/tune_driver.py
@@ -43,7 +43,22 @@ def _load_config(original_run_dir: Path) -> tuple[dict, str, str, int]:
         raise SystemExit(
             "config/run/reproduction.yaml must declare optuna.search_space and optuna.objective"
         )
+    _validate_search_space(search_space)
     return search_space, objective, direction, n_trials
+
+
+def _validate_search_space(search_space: dict) -> None:
+    for name, spec in search_space.items():
+        typ = spec.get("type", "float")
+        if typ == "categorical":
+            if "choices" not in spec:
+                raise SystemExit(
+                    f"optuna.search_space.{name}: type=categorical requires 'choices'"
+                )
+        elif "low" not in spec or "high" not in spec:
+            raise SystemExit(
+                f"optuna.search_space.{name}: type={typ} requires 'low' and 'high'"
+            )
 
 
 def _suggest(trial: optuna.Trial, name: str, spec: dict) -> Any:
@@ -64,21 +79,31 @@ def _run_experiment(
     cmd = [python, "-u", "-m", "src.main", "run=reproduction"]
     cmd += [f"run.{name}={value}" for name, value in overrides.items()]
     cmd += [f"results_dir={out_dir.resolve()}"]
-    subprocess.run(cmd, cwd=original_run_dir, check=False)
+    result = subprocess.run(cmd, cwd=original_run_dir, check=False)
+    if result.returncode != 0:
+        print(f"::warning::src.main exited with code {result.returncode} (cwd={out_dir})")
     return out_dir / "result.json"
 
 
 def _read_metric(result_path: Path, metric: str) -> float | None:
     try:
         data = json.loads(result_path.read_text())
-    except Exception:
+    except FileNotFoundError:
+        print(f"::warning::{result_path} was not created (src.main likely crashed)")
+        return None
+    except json.JSONDecodeError as e:
+        print(f"::warning::{result_path} is not valid JSON: {e}")
         return None
     for m in data.get("metrics", []):
         if isinstance(m, dict) and m.get("name") == metric:
             try:
                 return float(str(m.get("value")).strip())
             except (ValueError, TypeError):
+                print(
+                    f"::warning::metric '{metric}' in {result_path} is not numeric: {m.get('value')!r}"
+                )
                 return None
+    print(f"::warning::metric '{metric}' not found in {result_path}")
     return None
 
 

--- a/.github/scripts/paper_reproduction/tune_driver.py
+++ b/.github/scripts/paper_reproduction/tune_driver.py
@@ -10,8 +10,8 @@ Invocation of the reproduction (same Hydra entry point as the run workflow):
   → writes <dir>/result.json with "metrics": [{"name": ..., "value": ...}, ...]
 
 Usage:
-  python tune_driver.py --original-run-dir jobs/<id> --tune-output-dir jobs/<tid>/outputs \
-      --python jobs/<id>/.venv/bin/python [--n-trials 20]
+  python tune_driver.py --original-run-dir . --tune-output-dir .reproduction/tuning \
+      --python .venv/bin/python [--n-trials 20]
 """
 
 from __future__ import annotations

--- a/.github/scripts/paper_reproduction/tune_driver.py
+++ b/.github/scripts/paper_reproduction/tune_driver.py
@@ -1,0 +1,168 @@
+"""Fixed Optuna driver for parameter tuning — reuses the original reproduction's Hydra code.
+
+Tuning generates no code. This driver reads the original job's Hydra run config
+(config/run/reproduction.yaml) for the `optuna` search space + objective, then runs the reproduction's
+`src/main.py` with Hydra CLI parameter overrides for n_trials, re-runs the best trial, and writes
+tuning_figure.png + result.json under the tuning job's outputs/.
+
+Invocation of the reproduction (same Hydra entry point as the run workflow):
+  <python> -u -m src.main run=reproduction run.<name>=<value> ... results_dir=<dir>
+  → writes <dir>/result.json with "metrics": [{"name": ..., "value": ...}, ...]
+
+Usage:
+  python tune_driver.py --original-run-dir jobs/<id> --tune-output-dir jobs/<tid>/outputs \
+      --python jobs/<id>/.venv/bin/python [--n-trials 20]
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+from pathlib import Path
+from typing import Any
+
+import matplotlib
+
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt  # noqa: E402
+import optuna  # noqa: E402
+import yaml  # noqa: E402
+
+
+def _load_config(original_run_dir: Path) -> tuple[dict, str, str, int]:
+    cfg = yaml.safe_load(
+        (original_run_dir / "config" / "run" / "reproduction.yaml").read_text()
+    )
+    optuna_cfg = (cfg or {}).get("optuna") or {}
+    search_space = optuna_cfg.get("search_space") or {}
+    objective = optuna_cfg.get("objective")
+    direction = optuna_cfg.get("direction", "maximize")
+    n_trials = int(optuna_cfg.get("n_trials", 20))
+    if not search_space or not objective:
+        raise SystemExit(
+            "config/run/reproduction.yaml must declare optuna.search_space and optuna.objective"
+        )
+    return search_space, objective, direction, n_trials
+
+
+def _suggest(trial: optuna.Trial, name: str, spec: dict) -> Any:
+    typ = spec.get("type", "float")
+    if typ == "categorical":
+        return trial.suggest_categorical(name, spec["choices"])
+    low, high, log = spec["low"], spec["high"], bool(spec.get("log", False))
+    if typ == "int":
+        return trial.suggest_int(name, int(low), int(high), log=log)
+    return trial.suggest_float(name, float(low), float(high), log=log)
+
+
+def _run_experiment(
+    python: str, original_run_dir: Path, overrides: dict, out_dir: Path
+) -> Path:
+    """Run src/main.py with Hydra overrides; return the path to the trial's result.json."""
+    out_dir.mkdir(parents=True, exist_ok=True)
+    cmd = [python, "-u", "-m", "src.main", "run=reproduction"]
+    cmd += [f"run.{name}={value}" for name, value in overrides.items()]
+    cmd += [f"results_dir={out_dir.resolve()}"]
+    subprocess.run(cmd, cwd=original_run_dir, check=False)
+    return out_dir / "result.json"
+
+
+def _read_metric(result_path: Path, metric: str) -> float | None:
+    try:
+        data = json.loads(result_path.read_text())
+    except Exception:
+        return None
+    for m in data.get("metrics", []):
+        if isinstance(m, dict) and m.get("name") == metric:
+            try:
+                return float(str(m.get("value")).strip())
+            except (ValueError, TypeError):
+                return None
+    return None
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--original-run-dir", required=True, type=Path)
+    parser.add_argument("--tune-output-dir", required=True, type=Path)
+    parser.add_argument("--python", required=True, help="python that runs src.main")
+    parser.add_argument("--n-trials", type=int, default=None)
+    args = parser.parse_args()
+
+    search_space, metric, direction, n_trials = _load_config(args.original_run_dir)
+    if args.n_trials is not None:
+        n_trials = args.n_trials
+    args.tune_output_dir.mkdir(parents=True, exist_ok=True)
+    trials_root = args.tune_output_dir / "trials"
+
+    def objective(trial: optuna.Trial) -> float:
+        overrides = {
+            name: _suggest(trial, name, spec) for name, spec in search_space.items()
+        }
+        result_path = _run_experiment(
+            args.python,
+            args.original_run_dir,
+            overrides,
+            trials_root / f"trial_{trial.number}",
+        )
+        value = _read_metric(result_path, metric)
+        if value is None:
+            raise optuna.TrialPruned()
+        return value
+
+    study = optuna.create_study(
+        direction=direction, sampler=optuna.samplers.TPESampler(seed=42)
+    )
+    study.optimize(objective, n_trials=n_trials)
+
+    best_result = _run_experiment(
+        args.python, args.original_run_dir, study.best_params, args.tune_output_dir
+    )
+    best_value = _read_metric(best_result, metric)
+
+    _plot(study, metric, direction, args.tune_output_dir / "tuning_figure.png")
+
+    summary = (
+        f"## Parameter tuning\n\n"
+        f"| Item | Value |\n|---|---|\n"
+        f"| Method | Optuna (TPE) |\n| Trials | {len(study.trials)} |\n"
+        f"| Objective | {metric} ({direction}) |\n"
+        f"| Best trial | #{study.best_trial.number} → {study.best_value} |\n\n"
+        f"## Best parameters\n\n```json\n{json.dumps(study.best_params, indent=2)}\n```\n\n"
+        f"## Final performance\n\n{metric} = {best_value} (best params re-run)\n"
+    )
+    (args.tune_output_dir / "result.json").write_text(
+        json.dumps(
+            {
+                "summary": summary,
+                "artifacts": ["tuning_figure.png"],
+                "best_params": study.best_params,
+                "best_value": study.best_value,
+                "objective": {"metric": metric, "direction": direction},
+            },
+            ensure_ascii=False,
+            indent=2,
+        )
+    )
+    print(f"best_trial=#{study.best_trial.number} best_value={study.best_value}")
+
+
+def _plot(study: optuna.Study, metric: str, direction: str, path: Path) -> None:
+    values = [t.value for t in study.trials if t.value is not None]
+    best_so_far, cur = [], None
+    for v in values:
+        cur = v if cur is None else (max(cur, v) if direction == "maximize" else min(cur, v))
+        best_so_far.append(cur)
+    fig, ax = plt.subplots(figsize=(8, 5))
+    ax.plot(range(len(values)), values, "o", alpha=0.5, label="trial")
+    ax.plot(range(len(best_so_far)), best_so_far, "-", label="running best")
+    ax.set_xlabel("trial")
+    ax.set_ylabel(metric)
+    ax.set_title(f"Optuna tuning ({direction} {metric})")
+    ax.legend()
+    fig.savefig(path, dpi=150, bbox_inches="tight")
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/run_paper_reproduction_generate.yml
+++ b/.github/workflows/run_paper_reproduction_generate.yml
@@ -1,0 +1,182 @@
+name: "Run Paper Reproduction (generate)"
+run-name: "🤖 Paper Reproduction generate: ${{ inputs.run_id }}"
+
+on:
+  workflow_dispatch:
+    inputs:
+      branch_name:
+        description: 'Branch name (e.g., main)'
+        required: true
+        default: 'main'
+      run_id:
+        description: 'Run id. Deliverables are written under jobs/<run_id>/'
+        required: true
+      paper_url:
+        description: 'URL of the paper to reproduce (the agent fetches and reads it itself)'
+        required: true
+      repo_url:
+        description: "GitHub URL of the paper's implementation repository (empty: the agent searches with WebSearch)"
+        required: false
+        default: ''
+      instruction:
+        description: 'Natural language reproduction instruction'
+        required: true
+      target_kind:
+        description: 'Kind of the reproduction target'
+        required: true
+        type: choice
+        options:
+          - figure
+          - table
+      target_number:
+        description: 'Figure/table number (e.g. "Figure 3"). Leave empty if unknown'
+        required: false
+        default: ''
+      github_actions_agent:
+        description: 'AI agent tool to use (claude_code or open_code)'
+        required: true
+        type: choice
+        options:
+          - claude_code
+          - open_code
+        default: 'claude_code'
+      model_name:
+        description: 'Model to use (OpenCode: openrouter/openai/gpt-5-nano; Claude Code: sonnet/opus/haiku or full id)'
+        required: true
+        default: 'claude-sonnet-4-5-20250929'
+      prompt_path:
+        description: 'Path to the prompt template file'
+        required: false
+        default: '.github/prompts/run_paper_reproduction.md'
+      runner_label:
+        description: 'Runner label (e.g., ["ubuntu-latest"], ["self-hosted", "gpu-runner"])'
+        required: true
+        default: '["ubuntu-latest"]'
+
+permissions:
+  id-token: write
+  contents: write
+
+defaults:
+  run:
+    shell: bash
+
+env:
+  RUN_DIR: jobs/${{ github.event.inputs.run_id }}
+
+jobs:
+  generate:
+    name: Generate Reproduction Code
+    runs-on: ${{ fromJSON(github.event.inputs.runner_label) }}
+    timeout-minutes: 360
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.inputs.branch_name }}
+
+      - name: Prepare run directory
+        run: mkdir -p "$RUN_DIR"
+
+      - name: Clone target paper repository
+        if: github.event.inputs.repo_url != ''
+        env:
+          REPO_URL: ${{ github.event.inputs.repo_url }}
+        run: |
+          set -eu
+          git clone --depth 1 -- "$REPO_URL" "$RUN_DIR/repo"
+
+      - name: Build generation prompt
+        id: build-prompt
+        env:
+          PROMPT_PATH: ${{ github.event.inputs.prompt_path }}
+          RUN_ID: ${{ github.event.inputs.run_id }}
+          PAPER_URL: ${{ github.event.inputs.paper_url }}
+          INSTRUCTION: ${{ github.event.inputs.instruction }}
+          TARGET_KIND: ${{ github.event.inputs.target_kind }}
+          TARGET_NUMBER: ${{ github.event.inputs.target_number }}
+          REPO_URL: ${{ github.event.inputs.repo_url }}
+        run: |
+          set -e
+          if [ ! -f "$PROMPT_PATH" ]; then
+            echo "::error::Prompt file not found: $PROMPT_PATH"
+            exit 1
+          fi
+
+          PROMPT_FILE="/tmp/paper_reproduction_prompt.txt"
+          {
+            cat "$PROMPT_PATH"
+            echo ""
+            echo "RUN_ID: $RUN_ID"
+            echo "PAPER_URL: $PAPER_URL"
+            echo "INSTRUCTION:"
+            printf "%s\n" "$INSTRUCTION"
+            echo "TARGET_KIND: $TARGET_KIND"
+            echo "TARGET_NUMBER: $TARGET_NUMBER"
+            echo "REPO_URL: $REPO_URL"
+          } > "$PROMPT_FILE"
+
+          echo "prompt_file=$PROMPT_FILE" >> "$GITHUB_OUTPUT"
+          echo "Prompt saved to: $PROMPT_FILE ($(wc -c < "$PROMPT_FILE") bytes)"
+
+      - name: Run Claude Code for reproduction code
+        if: github.event.inputs.github_actions_agent == 'claude_code'
+        timeout-minutes: 180
+        uses: ./.github/actions/run-claude-code
+        with:
+          prompt_file: ${{ steps.build-prompt.outputs.prompt_file }}
+          model_name: ${{ github.event.inputs.model_name }}
+          max_turns: '80'
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          HF_TOKEN: ${{ secrets.HF_TOKEN }}
+
+      - name: Run OpenCode for reproduction code
+        if: github.event.inputs.github_actions_agent == 'open_code'
+        timeout-minutes: 180
+        uses: ./.github/actions/run-open-code
+        with:
+          prompt_file: ${{ steps.build-prompt.outputs.prompt_file }}
+          model_name: ${{ github.event.inputs.model_name }}
+        env:
+          HF_TOKEN: ${{ secrets.HF_TOKEN }}
+          LANGFUSE_PUBLIC_KEY: ${{ secrets.LANGFUSE_PUBLIC_KEY }}
+          LANGFUSE_SECRET_KEY: ${{ secrets.LANGFUSE_SECRET_KEY }}
+          LANGFUSE_BASEURL: ${{ secrets.LANGFUSE_BASE_URL }}
+
+          OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          GOOGLE_API_KEY: ${{ secrets.GEMINI_API_KEY }}
+
+          AZURE_OPENAI_API_KEY: ${{ secrets.AZURE_OPENAI_API_KEY }}
+          AZURE_OPENAI_ENDPOINT: ${{ secrets.AZURE_OPENAI_ENDPOINT }}
+          AZURE_OPENAI_API_VERSION: "2024-10-01-preview"
+
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_DEFAULT_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
+
+      - name: Commit and push generated code
+        env:
+          RUN_ID: ${{ github.event.inputs.run_id }}
+          BRANCH_NAME: ${{ github.event.inputs.branch_name }}
+        run: |
+          git config --local user.name "github-actions[bot]"
+          git config --local user.email "github-actions[bot]@users.noreply.github.com"
+          git remote set-url origin "https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}"
+          git add -- "$RUN_DIR"
+
+          if ! git diff --staged --quiet; then
+            git commit -m "[CI] Paper reproduction generate for run_id=$RUN_ID using ${{ github.event.inputs.github_actions_agent }}"
+            git checkout -- .
+            for i in {1..5}; do
+              git pull --rebase -X theirs origin "$BRANCH_NAME"
+              git push origin "HEAD:$BRANCH_NAME" && break
+              echo "Push failed on attempt $i. Retrying in $((2**i)) seconds..."
+              sleep $((2**i))
+            done
+          else
+            echo "The agent generated no code for run_id=$RUN_ID."
+          fi

--- a/.github/workflows/run_paper_reproduction_generate.yml
+++ b/.github/workflows/run_paper_reproduction_generate.yml
@@ -1,5 +1,5 @@
 name: "Run Paper Reproduction (generate)"
-run-name: "🤖 Paper Reproduction generate: ${{ inputs.run_id }}"
+run-name: "🤖 Paper Reproduction generate"
 
 on:
   workflow_dispatch:
@@ -8,9 +8,6 @@ on:
         description: 'Branch name (e.g., main)'
         required: true
         default: 'main'
-      run_id:
-        description: 'Run id. Deliverables are written under jobs/<run_id>/'
-        required: true
       paper_url:
         description: 'URL of the paper to reproduce (the agent fetches and reads it itself)'
         required: true
@@ -19,19 +16,8 @@ on:
         required: false
         default: ''
       instruction:
-        description: 'Natural language reproduction instruction'
+        description: 'Natural language reproduction instruction (may hint which figure/table; the agent picks the target from the paper)'
         required: true
-      target_kind:
-        description: 'Kind of the reproduction target'
-        required: true
-        type: choice
-        options:
-          - figure
-          - table
-      target_number:
-        description: 'Figure/table number (e.g. "Figure 3"). Leave empty if unknown'
-        required: false
-        default: ''
       github_actions_agent:
         description: 'AI agent tool to use (claude_code or open_code)'
         required: true
@@ -41,9 +27,9 @@ on:
           - open_code
         default: 'claude_code'
       model_name:
-        description: 'Model to use (OpenCode: openrouter/openai/gpt-5-nano; Claude Code: sonnet/opus/haiku or full id)'
+        description: 'Model to use (OpenCode: openrouter/openai/gpt-5-nano, Claude Code: sonnet/opus/haiku)'
         required: true
-        default: 'claude-sonnet-4-5-20250929'
+        default: 'sonnet'
       prompt_path:
         description: 'Path to the prompt template file'
         required: false
@@ -61,14 +47,11 @@ defaults:
   run:
     shell: bash
 
-env:
-  RUN_DIR: jobs/${{ github.event.inputs.run_id }}
-
 jobs:
   generate:
     name: Generate Reproduction Code
     runs-on: ${{ fromJSON(github.event.inputs.runner_label) }}
-    timeout-minutes: 360
+    timeout-minutes: 60
 
     steps:
       - name: Checkout repository
@@ -76,8 +59,8 @@ jobs:
         with:
           ref: ${{ github.event.inputs.branch_name }}
 
-      - name: Prepare run directory
-        run: mkdir -p "$RUN_DIR"
+      - name: Prepare reproduction directory
+        run: mkdir -p .reproduction
 
       - name: Clone target paper repository
         if: github.event.inputs.repo_url != ''
@@ -85,17 +68,14 @@ jobs:
           REPO_URL: ${{ github.event.inputs.repo_url }}
         run: |
           set -eu
-          git clone --depth 1 -- "$REPO_URL" "$RUN_DIR/repo"
+          git clone --depth 1 -- "$REPO_URL" .reproduction/repo
 
       - name: Build generation prompt
         id: build-prompt
         env:
           PROMPT_PATH: ${{ github.event.inputs.prompt_path }}
-          RUN_ID: ${{ github.event.inputs.run_id }}
           PAPER_URL: ${{ github.event.inputs.paper_url }}
           INSTRUCTION: ${{ github.event.inputs.instruction }}
-          TARGET_KIND: ${{ github.event.inputs.target_kind }}
-          TARGET_NUMBER: ${{ github.event.inputs.target_number }}
           REPO_URL: ${{ github.event.inputs.repo_url }}
         run: |
           set -e
@@ -108,12 +88,9 @@ jobs:
           {
             cat "$PROMPT_PATH"
             echo ""
-            echo "RUN_ID: $RUN_ID"
             echo "PAPER_URL: $PAPER_URL"
             echo "INSTRUCTION:"
             printf "%s\n" "$INSTRUCTION"
-            echo "TARGET_KIND: $TARGET_KIND"
-            echo "TARGET_NUMBER: $TARGET_NUMBER"
             echo "REPO_URL: $REPO_URL"
           } > "$PROMPT_FILE"
 
@@ -122,19 +99,17 @@ jobs:
 
       - name: Run Claude Code for reproduction code
         if: github.event.inputs.github_actions_agent == 'claude_code'
-        timeout-minutes: 180
         uses: ./.github/actions/run-claude-code
         with:
           prompt_file: ${{ steps.build-prompt.outputs.prompt_file }}
           model_name: ${{ github.event.inputs.model_name }}
-          max_turns: '80'
+          timeout_minutes: '45'
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           HF_TOKEN: ${{ secrets.HF_TOKEN }}
 
       - name: Run OpenCode for reproduction code
         if: github.event.inputs.github_actions_agent == 'open_code'
-        timeout-minutes: 180
         uses: ./.github/actions/run-open-code
         with:
           prompt_file: ${{ steps.build-prompt.outputs.prompt_file }}
@@ -160,16 +135,16 @@ jobs:
 
       - name: Commit and push generated code
         env:
-          RUN_ID: ${{ github.event.inputs.run_id }}
           BRANCH_NAME: ${{ github.event.inputs.branch_name }}
         run: |
           git config --local user.name "github-actions[bot]"
           git config --local user.email "github-actions[bot]@users.noreply.github.com"
           git remote set-url origin "https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}"
-          git add -- "$RUN_DIR"
+          git add -A -- config src .reproduction
+          git add -- requirements.txt Dockerfile 2>/dev/null || true
 
           if ! git diff --staged --quiet; then
-            git commit -m "[CI] Paper reproduction generate for run_id=$RUN_ID using ${{ github.event.inputs.github_actions_agent }}"
+            git commit -m "[CI] Paper reproduction generate using ${{ github.event.inputs.github_actions_agent }}"
             git checkout -- .
             for i in {1..5}; do
               git pull --rebase -X theirs origin "$BRANCH_NAME"
@@ -178,5 +153,5 @@ jobs:
               sleep $((2**i))
             done
           else
-            echo "The agent generated no code for run_id=$RUN_ID."
+            echo "The agent generated no code."
           fi

--- a/.github/workflows/run_paper_reproduction_generate.yml
+++ b/.github/workflows/run_paper_reproduction_generate.yml
@@ -69,6 +69,23 @@ jobs:
       - name: Prepare reproduction directory
         run: mkdir -p "$REPRO_DIR"
 
+      - name: Install uv
+        uses: Wandalen/wretry.action@v3
+        with:
+          action: astral-sh/setup-uv@v6
+          with: |
+            python-version: "3.11"
+          attempt_limit: 3
+          attempt_delay: 30000
+
+      - name: Fetch arXiv TeX source (if applicable)
+        env:
+          PAPER_URL: ${{ github.event.inputs.paper_url }}
+        run: |
+          uv run python3 .github/scripts/paper_reproduction/fetch_arxiv_tex_source.py \
+            --paper-url "$PAPER_URL" \
+            --repro-dir "$REPRO_DIR"
+
       - name: Clone target paper repository
         if: github.event.inputs.repo_url != ''
         env:
@@ -140,6 +157,59 @@ jobs:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           AWS_DEFAULT_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
+
+      # Paper extraction runs in its own agent process, after code generation, so it only ever sees
+      # the parameter key schema (below) — never the config values the code-generation agent chose.
+      # claude_code only for now; open_code isn't wired up here.
+      - name: Extract parameter key schema from generated config
+        id: extract-schema
+        if: github.event.inputs.github_actions_agent == 'claude_code'
+        run: |
+          set -eu
+          CONFIG_PATH="$REPRO_DIR/config/run/reproduction.yaml"
+          if [ ! -f "$CONFIG_PATH" ]; then
+            echo "::warning::$CONFIG_PATH not found (early exit or generation failure); skipping paper extraction."
+            echo "has_schema=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          PARAM_KEYS=$(uv run --with pyyaml python3 .github/scripts/paper_reproduction/extract_config_keys.py --config "$CONFIG_PATH")
+          if [ -z "$PARAM_KEYS" ]; then
+            echo "::warning::No parameter keys found in $CONFIG_PATH; skipping paper extraction."
+            echo "has_schema=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo "has_schema=true" >> "$GITHUB_OUTPUT"
+          {
+            echo "param_keys<<PARAM_KEYS_EOF"
+            echo "$PARAM_KEYS"
+            echo "PARAM_KEYS_EOF"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Build paper extraction prompt
+        id: build-extraction-prompt
+        if: steps.extract-schema.outputs.has_schema == 'true'
+        env:
+          PARAM_KEYS: ${{ steps.extract-schema.outputs.param_keys }}
+        run: |
+          set -e
+          PROMPT_FILE="/tmp/paper_extraction_prompt.txt"
+          {
+            cat ".github/prompts/run_paper_extraction.md"
+            echo "REPRO_DIR: $REPRO_DIR"
+            printf "%s\n" "$PARAM_KEYS"
+          } > "$PROMPT_FILE"
+          echo "prompt_file=$PROMPT_FILE" >> "$GITHUB_OUTPUT"
+          echo "Prompt saved to: $PROMPT_FILE ($(wc -c < "$PROMPT_FILE") bytes)"
+
+      - name: Run Claude Code for paper extraction
+        if: steps.extract-schema.outputs.has_schema == 'true'
+        uses: ./.github/actions/run-claude-code
+        with:
+          prompt_file: ${{ steps.build-extraction-prompt.outputs.prompt_file }}
+          model_name: ${{ github.event.inputs.model_name }}
+          timeout_minutes: '15'
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
 
       - name: Commit and push generated code
         env:

--- a/.github/workflows/run_paper_reproduction_generate.yml
+++ b/.github/workflows/run_paper_reproduction_generate.yml
@@ -8,6 +8,9 @@ on:
         description: 'Branch name (e.g., main)'
         required: true
         default: 'main'
+      repro_id:
+        description: 'Reproduction ID (directory name under .reproduction/)'
+        required: true
       paper_url:
         description: 'URL of the paper to reproduce (the agent fetches and reads it itself)'
         required: true
@@ -48,6 +51,9 @@ defaults:
   run:
     shell: bash
 
+env:
+  REPRO_DIR: .reproduction/${{ github.event.inputs.repro_id }}
+
 jobs:
   generate:
     name: Generate Reproduction Code
@@ -61,7 +67,7 @@ jobs:
           ref: ${{ github.event.inputs.branch_name }}
 
       - name: Prepare reproduction directory
-        run: mkdir -p .reproduction
+        run: mkdir -p "$REPRO_DIR"
 
       - name: Clone target paper repository
         if: github.event.inputs.repo_url != ''
@@ -69,7 +75,7 @@ jobs:
           REPO_URL: ${{ github.event.inputs.repo_url }}
         run: |
           set -eu
-          git clone --depth 1 -- "$REPO_URL" .reproduction/repo
+          git clone --depth 1 -- "$REPO_URL" "$REPRO_DIR/repo"
 
       - name: Build generation prompt
         id: build-prompt
@@ -93,6 +99,7 @@ jobs:
             echo "INSTRUCTION:"
             printf "%s\n" "$INSTRUCTION"
             echo "REPO_URL: $REPO_URL"
+            echo "REPRO_DIR: $REPRO_DIR"
           } > "$PROMPT_FILE"
 
           echo "prompt_file=$PROMPT_FILE" >> "$GITHUB_OUTPUT"
@@ -141,8 +148,7 @@ jobs:
           git config --local user.name "github-actions[bot]"
           git config --local user.email "github-actions[bot]@users.noreply.github.com"
           git remote set-url origin "https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}"
-          git add -A -- config src .reproduction
-          git add -- requirements.txt Dockerfile 2>/dev/null || true
+          git add -A -- "$REPRO_DIR"
 
           if ! git diff --staged --quiet; then
             git commit -m "[CI] Paper reproduction generate using ${{ github.event.inputs.github_actions_agent }}"

--- a/.github/workflows/run_paper_reproduction_generate.yml
+++ b/.github/workflows/run_paper_reproduction_generate.yml
@@ -16,8 +16,9 @@ on:
         required: false
         default: ''
       instruction:
-        description: 'Natural language reproduction instruction (may hint which figure/table; the agent picks the target from the paper)'
-        required: true
+        description: 'Natural language reproduction instruction (may hint which figure/table; empty: the agent picks the target from the paper)'
+        required: false
+        default: ''
       github_actions_agent:
         description: 'AI agent tool to use (claude_code or open_code)'
         required: true

--- a/.github/workflows/run_paper_reproduction_run.yml
+++ b/.github/workflows/run_paper_reproduction_run.yml
@@ -1,0 +1,210 @@
+name: "Run Paper Reproduction (run)"
+run-name: "🤖 Paper Reproduction run: ${{ inputs.run_id }}"
+
+# Agentless deterministic execution. The generate workflow committed src/main.py + config + paper.txt
+# under jobs/<run_id>/; a plain checkout restores them. This job runs src/main.py via Hydra, in Docker
+# if the generated code includes a Dockerfile, otherwise natively with uv.
+
+on:
+  workflow_dispatch:
+    inputs:
+      branch_name:
+        description: 'Branch name (e.g., main)'
+        required: true
+        default: 'main'
+      run_id:
+        description: 'Run id created by run_paper_reproduction_generate.yml'
+        required: true
+      repo_url:
+        description: "GitHub URL of the paper's implementation repository (same as the generate job)"
+        required: false
+        default: ''
+      runner_label:
+        description: 'Runner label (e.g., ["ubuntu-latest"], ["self-hosted", "gpu-runner"])'
+        required: true
+        default: '["ubuntu-latest"]'
+
+permissions:
+  id-token: write
+  contents: write
+
+defaults:
+  run:
+    shell: bash
+
+env:
+  RESULTS_DIR: outputs
+
+jobs:
+  run:
+    name: Run Reproduction
+    runs-on: ${{ fromJSON(github.event.inputs.runner_label) }}
+    timeout-minutes: 360
+
+    env:
+      BRANCH_NAME: ${{ github.event.inputs.branch_name }}
+      RUN_ID: ${{ github.event.inputs.run_id }}
+      RUN_DIR: jobs/${{ github.event.inputs.run_id }}
+      REPO_URL: ${{ github.event.inputs.repo_url }}
+      # Experiments that call an LLM/API at runtime may use these.
+      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+      AWS_BEARER_TOKEN_BEDROCK: ${{ secrets.AWS_BEARER_TOKEN_BEDROCK }}
+      GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
+      HF_TOKEN: ${{ secrets.HF_TOKEN }}
+      LANGFUSE_BASE_URL: ${{ secrets.LANGFUSE_BASE_URL }}
+      LANGFUSE_PUBLIC_KEY: ${{ secrets.LANGFUSE_PUBLIC_KEY }}
+      LANGFUSE_SECRET_KEY: ${{ secrets.LANGFUSE_SECRET_KEY }}
+      OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+      OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
+      WANDB_API_KEY: ${{ secrets.WANDB_API_KEY }}
+
+    steps:
+      # The checkout also restores the generated src/main.py + config + paper.txt (jobs/<run_id>/),
+      # which run_paper_reproduction_generate.yml committed to this branch.
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.inputs.branch_name }}
+
+      - name: Validate generated run directory
+        run: |
+          set -eu
+          if [ ! -f "$RUN_DIR/src/main.py" ] || [ ! -f "$RUN_DIR/config/config.yaml" ]; then
+            echo "::error::$RUN_DIR/src/main.py or config/config.yaml is missing on this branch. run_paper_reproduction_generate.yml for run_id=$RUN_ID must have completed and pushed first."
+            exit 1
+          fi
+
+      # jobs/<run_id>/repo is gitignored, so it must be re-cloned here.
+      - name: Re-clone target paper repository
+        if: github.event.inputs.repo_url != ''
+        run: |
+          set -eu
+          git clone --depth 1 -- "$REPO_URL" "$RUN_DIR/repo"
+
+      - name: Check Docker and Dockerfile availability
+        id: check-docker
+        run: |
+          has_docker=false
+          has_dockerfile=false
+          if docker info > /dev/null 2>&1; then has_docker=true; fi
+          if [ -f "$RUN_DIR/Dockerfile" ]; then has_dockerfile=true; fi
+          echo "has_docker=$has_docker" >> "$GITHUB_OUTPUT"
+          echo "has_dockerfile=$has_dockerfile" >> "$GITHUB_OUTPUT"
+
+      - name: Prepare results dir
+        run: mkdir -p "$RUN_DIR/$RESULTS_DIR"
+
+      - name: Build Docker image
+        if: steps.check-docker.outputs.has_docker == 'true' && steps.check-docker.outputs.has_dockerfile == 'true'
+        id: build-docker
+        continue-on-error: true
+        run: |
+          (
+            set -e
+            echo "=== [DOCKER BUILD] Start at $(date -u) ==="
+            docker build -t airas-repro:latest "$RUN_DIR"
+            echo "=== [DOCKER BUILD] Success at $(date -u) ==="
+          ) 2>&1 | tee -a "$RUN_DIR/$RESULTS_DIR/run.log"
+
+      - name: Install uv (fallback if no Docker)
+        if: steps.check-docker.outputs.has_docker == 'false' || steps.check-docker.outputs.has_dockerfile == 'false' || steps.build-docker.outcome != 'success'
+        uses: astral-sh/setup-uv@v6
+        with:
+          python-version: "3.11"
+
+      - name: Run reproduction (Docker)
+        if: steps.check-docker.outputs.has_docker == 'true' && steps.check-docker.outputs.has_dockerfile == 'true' && steps.build-docker.outcome == 'success'
+        id: run-docker
+        continue-on-error: true
+        run: |
+          GPU_FLAGS=""
+          if nvidia-smi > /dev/null 2>&1; then GPU_FLAGS="--gpus all"; fi
+          docker run --rm $GPU_FLAGS \
+            -v "$(pwd)/$RUN_DIR/$RESULTS_DIR:/workspace/$RESULTS_DIR" \
+            -e ANTHROPIC_API_KEY -e AWS_BEARER_TOKEN_BEDROCK -e GEMINI_API_KEY -e HF_TOKEN \
+            -e OPENAI_API_KEY -e OPENROUTER_API_KEY -e WANDB_API_KEY \
+            airas-repro:latest \
+            bash -c '
+              set -e
+              echo "=== [REPRODUCE] Start at $(date -u) ==="
+              python -u -m src.main run=reproduction results_dir="'"$RESULTS_DIR"'"
+              echo "=== [REPRODUCE] PASSED at $(date -u) ==="
+            ' 2>&1 | tee -a "$RUN_DIR/$RESULTS_DIR/run.log"
+
+      - name: Run reproduction (native)
+        if: steps.check-docker.outputs.has_docker == 'false' || steps.check-docker.outputs.has_dockerfile == 'false' || steps.build-docker.outcome != 'success'
+        id: run-native
+        continue-on-error: true
+        run: |
+          set -eu
+          cd "$RUN_DIR"
+          uv venv .venv
+          uv pip install --no-cache --python .venv/bin/python hydra-core
+          if [ -f repo/requirements.txt ]; then
+            uv pip install --no-cache --python .venv/bin/python -r repo/requirements.txt 2>&1 | tee -a "$RESULTS_DIR/run.log" || true
+          fi
+          uv pip install --no-cache --python .venv/bin/python -e repo 2>/dev/null || true
+          if [ -f requirements.txt ]; then
+            uv pip install --no-cache --python .venv/bin/python -r requirements.txt 2>&1 | tee -a "$RESULTS_DIR/run.log" || true
+          fi
+          echo "=== [REPRODUCE] Start at $(date -u) ===" | tee -a "$RESULTS_DIR/run.log"
+          .venv/bin/python -u -m src.main run=reproduction results_dir="$RESULTS_DIR" 2>&1 | tee -a "$RESULTS_DIR/run.log"
+          echo "=== [REPRODUCE] PASSED at $(date -u) ===" | tee -a "$RESULTS_DIR/run.log"
+
+      - name: Determine run outcome
+        id: run-outcome
+        if: always()
+        run: |
+          set -eu
+          OUT="$RUN_DIR/$RESULTS_DIR"
+          outcome="${{ steps.run-docker.outcome }}${{ steps.run-native.outcome }}"
+          STATUS="passed"
+          if [[ "$outcome" != *"success"* ]] || [ ! -f "$OUT/result.json" ]; then
+            STATUS="failed"
+          elif [ ! -f "$OUT/repro.png" ] && [ ! -f "$OUT/repro.md" ]; then
+            STATUS="failed"
+          fi
+          echo "status=$STATUS" >> "$GITHUB_OUTPUT"
+
+      # Backup/debug copy of the outputs as an artifact (matching the experiment workflows). The
+      # authoritative copy for fetch_paper_reproduction_results is the git commit below.
+      - name: Upload results
+        if: always()
+        uses: Wandalen/wretry.action@v3
+        with:
+          action: actions/upload-artifact@v4
+          with: |
+            name: paper-reproduction-${{ github.run_id }}-${{ github.event.inputs.run_id }}
+            path: ${{ env.RUN_DIR }}/${{ env.RESULTS_DIR }}
+            if-no-files-found: warn
+          attempt_limit: 3
+          attempt_delay: 30000
+
+      # Persist results to the branch, even on failure: fetch_paper_reproduction_results reads them
+      # from git via the Contents API (artifacts are not readable that way).
+      - name: Commit and push results
+        if: always()
+        run: |
+          git config --local user.name "github-actions[bot]"
+          git config --local user.email "github-actions[bot]@users.noreply.github.com"
+          git remote set-url origin "https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}"
+          git add -- "$RUN_DIR"
+
+          if ! git diff --staged --quiet; then
+            git commit -m "[CI] Paper reproduction run for run_id=$RUN_ID"
+            git checkout -- .
+            for i in {1..5}; do
+              git pull --rebase -X theirs origin "$BRANCH_NAME"
+              git push origin "HEAD:$BRANCH_NAME" && break
+              echo "Push failed on attempt $i. Retrying in $((2**i)) seconds..."
+              sleep $((2**i))
+            done
+          else
+            echo "No results to commit for run_id=$RUN_ID"
+          fi
+
+      - name: Fail job if run did not produce results
+        if: steps.run-outcome.outputs.status == 'failed'
+        run: |
+          echo "::error::src/main.py did not produce result.json + repro.(png|md). See $RESULTS_DIR/run.log."
+          exit 1

--- a/.github/workflows/run_paper_reproduction_run.yml
+++ b/.github/workflows/run_paper_reproduction_run.yml
@@ -8,6 +8,9 @@ on:
         description: 'Branch name (e.g., main)'
         required: true
         default: 'main'
+      repro_id:
+        description: 'Reproduction ID (directory name under .reproduction/)'
+        required: true
       repo_url:
         description: "GitHub URL of the paper's implementation repository (same as the generate job)"
         required: false
@@ -27,7 +30,9 @@ defaults:
     shell: bash
 
 env:
-  RESULTS_DIR: .reproduction/results
+  REPRO_DIR: .reproduction/${{ github.event.inputs.repro_id }}
+  RESULTS_DIR: .reproduction/${{ github.event.inputs.repro_id }}/results
+  IMAGE_TAG: repro-${{ github.event.inputs.repro_id }}
 
 jobs:
   run:
@@ -58,17 +63,17 @@ jobs:
       - name: Validate generated code
         run: |
           set -eu
-          if [ ! -f "src/main.py" ] || [ ! -f "config/config.yaml" ]; then
-            echo "::error::src/main.py or config/config.yaml is missing on this branch. run_paper_reproduction_generate.yml must have completed and pushed first."
+          if [ ! -f "$REPRO_DIR/src/main.py" ] || [ ! -f "$REPRO_DIR/config/config.yaml" ]; then
+            echo "::error::$REPRO_DIR/src/main.py or $REPRO_DIR/config/config.yaml is missing on this branch. run_paper_reproduction_generate.yml must have completed with this repro_id first."
             exit 1
           fi
 
-      # .reproduction/repo is gitignored, so it must be re-cloned here.
+      # <repro_dir>/repo is gitignored, so it must be re-cloned here.
       - name: Re-clone target paper repository
         if: github.event.inputs.repo_url != ''
         run: |
           set -eu
-          git clone --depth 1 -- "$REPO_URL" .reproduction/repo
+          git clone --depth 1 -- "$REPO_URL" "$REPRO_DIR/repo"
 
       - name: Check Docker and Dockerfile availability
         id: check-docker
@@ -83,11 +88,11 @@ jobs:
             echo "Docker is not available, will use native execution"
           fi
 
-          if [ -f "Dockerfile" ]; then
+          if [ -f "$REPRO_DIR/Dockerfile" ]; then
             has_dockerfile=true
-            echo "Dockerfile found"
+            echo "Dockerfile found in $REPRO_DIR"
           else
-            echo "Dockerfile not found"
+            echo "Dockerfile not found in $REPRO_DIR"
           fi
 
           echo "has_docker=$has_docker" >> "$GITHUB_OUTPUT"
@@ -108,7 +113,7 @@ jobs:
             (
               set -e
               echo "=== [DOCKER BUILD] Start at $(date -u) ==="
-              docker build -t airas-repro:latest .
+              docker build -t "airas-repro:${IMAGE_TAG,,}" "$REPRO_DIR"
               echo "=== [DOCKER BUILD] Success at $(date -u) ==="
             ) 2>&1 | tee -a "$RESULTS_DIR/docker_build.log"
 
@@ -149,7 +154,7 @@ jobs:
             fi
 
             docker run --rm $GPU_FLAGS \
-              -v "$(pwd)/$RESULTS_DIR:/workspace/$RESULTS_DIR" \
+              -v "$(pwd)/$RESULTS_DIR:/workspace/results" \
               -e ANTHROPIC_API_KEY \
               -e AWS_BEARER_TOKEN_BEDROCK \
               -e GEMINI_API_KEY \
@@ -160,12 +165,12 @@ jobs:
               -e OPENAI_API_KEY \
               -e OPENROUTER_API_KEY \
               -e WANDB_API_KEY \
-              airas-repro:latest \
+              "airas-repro:${IMAGE_TAG,,}" \
               bash -c '
                 set -e
                 set -o pipefail
                 echo "=== [REPRODUCE] Start at $(date -u) ==="
-                python -u -m src.main run=reproduction results_dir="'"$RESULTS_DIR"'"
+                python -u -m src.main run=reproduction results_dir=results
                 echo "=== [REPRODUCE] PASSED at $(date -u) ==="
               ' > >(tee -a "$RESULTS_DIR/run.log") 2>&1
 
@@ -182,17 +187,18 @@ jobs:
             (
               set -e
               set -o pipefail
+              cd "$REPRO_DIR"
               uv venv .venv
               uv pip install --no-cache --python .venv/bin/python hydra-core
-              if [ -f .reproduction/repo/requirements.txt ]; then
-                uv pip install --no-cache --python .venv/bin/python -r .reproduction/repo/requirements.txt || true
+              if [ -f repo/requirements.txt ]; then
+                uv pip install --no-cache --python .venv/bin/python -r repo/requirements.txt || true
               fi
-              uv pip install --no-cache --python .venv/bin/python -e .reproduction/repo 2>/dev/null || true
+              uv pip install --no-cache --python .venv/bin/python -e repo 2>/dev/null || true
               if [ -f requirements.txt ]; then
                 uv pip install --no-cache --python .venv/bin/python -r requirements.txt || true
               fi
               echo "=== [REPRODUCE] Start at $(date -u) ==="
-              .venv/bin/python -u -m src.main run=reproduction results_dir="$RESULTS_DIR"
+              .venv/bin/python -u -m src.main run=reproduction results_dir=results
               echo "=== [REPRODUCE] PASSED at $(date -u) ==="
             ) > >(tee -a "$RESULTS_DIR/run.log") 2>&1
 
@@ -217,7 +223,7 @@ jobs:
         with:
           action: actions/upload-artifact@v4
           with: |
-            name: paper-reproduction-${{ github.run_id }}
+            name: paper-reproduction-${{ github.event.inputs.repro_id }}-${{ github.run_id }}
             path: ${{ env.RESULTS_DIR }}
             if-no-files-found: warn
           attempt_limit: 3
@@ -231,7 +237,7 @@ jobs:
           git config --local user.name "github-actions[bot]"
           git config --local user.email "github-actions[bot]@users.noreply.github.com"
           git remote set-url origin "https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}"
-          git add -A -- .reproduction/results
+          git add -A -- "$RESULTS_DIR"
 
           if ! git diff --staged --quiet; then
             git commit -m "[CI] Paper reproduction run results"
@@ -249,5 +255,5 @@ jobs:
       - name: Fail job if run did not produce results
         if: steps.run-outcome.outputs.status == 'failed'
         run: |
-          echo "::error::src/main.py did not produce result.json + repro.(png|md). See $RESULTS_DIR/run.log."
+          echo "::error::$REPRO_DIR/src/main.py did not produce result.json + repro.(png|md). See $RESULTS_DIR/run.log."
           exit 1

--- a/.github/workflows/run_paper_reproduction_run.yml
+++ b/.github/workflows/run_paper_reproduction_run.yml
@@ -1,9 +1,5 @@
 name: "Run Paper Reproduction (run)"
-run-name: "🤖 Paper Reproduction run: ${{ inputs.run_id }}"
-
-# Agentless deterministic execution. The generate workflow committed src/main.py + config + paper.txt
-# under jobs/<run_id>/; a plain checkout restores them. This job runs src/main.py via Hydra, in Docker
-# if the generated code includes a Dockerfile, otherwise natively with uv.
+run-name: "🤖 Paper Reproduction run"
 
 on:
   workflow_dispatch:
@@ -12,9 +8,6 @@ on:
         description: 'Branch name (e.g., main)'
         required: true
         default: 'main'
-      run_id:
-        description: 'Run id created by run_paper_reproduction_generate.yml'
-        required: true
       repo_url:
         description: "GitHub URL of the paper's implementation repository (same as the generate job)"
         required: false
@@ -27,26 +20,24 @@ on:
 permissions:
   id-token: write
   contents: write
+  actions: write
 
 defaults:
   run:
     shell: bash
 
 env:
-  RESULTS_DIR: outputs
+  RESULTS_DIR: .reproduction/results
 
 jobs:
   run:
     name: Run Reproduction
     runs-on: ${{ fromJSON(github.event.inputs.runner_label) }}
-    timeout-minutes: 360
+    timeout-minutes: 600
 
     env:
       BRANCH_NAME: ${{ github.event.inputs.branch_name }}
-      RUN_ID: ${{ github.event.inputs.run_id }}
-      RUN_DIR: jobs/${{ github.event.inputs.run_id }}
       REPO_URL: ${{ github.event.inputs.repo_url }}
-      # Experiments that call an LLM/API at runtime may use these.
       ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
       AWS_BEARER_TOKEN_BEDROCK: ${{ secrets.AWS_BEARER_TOKEN_BEDROCK }}
       GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
@@ -59,123 +50,175 @@ jobs:
       WANDB_API_KEY: ${{ secrets.WANDB_API_KEY }}
 
     steps:
-      # The checkout also restores the generated src/main.py + config + paper.txt (jobs/<run_id>/),
-      # which run_paper_reproduction_generate.yml committed to this branch.
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
           ref: ${{ github.event.inputs.branch_name }}
 
-      - name: Validate generated run directory
+      - name: Validate generated code
         run: |
           set -eu
-          if [ ! -f "$RUN_DIR/src/main.py" ] || [ ! -f "$RUN_DIR/config/config.yaml" ]; then
-            echo "::error::$RUN_DIR/src/main.py or config/config.yaml is missing on this branch. run_paper_reproduction_generate.yml for run_id=$RUN_ID must have completed and pushed first."
+          if [ ! -f "src/main.py" ] || [ ! -f "config/config.yaml" ]; then
+            echo "::error::src/main.py or config/config.yaml is missing on this branch. run_paper_reproduction_generate.yml must have completed and pushed first."
             exit 1
           fi
 
-      # jobs/<run_id>/repo is gitignored, so it must be re-cloned here.
+      # .reproduction/repo is gitignored, so it must be re-cloned here.
       - name: Re-clone target paper repository
         if: github.event.inputs.repo_url != ''
         run: |
           set -eu
-          git clone --depth 1 -- "$REPO_URL" "$RUN_DIR/repo"
+          git clone --depth 1 -- "$REPO_URL" .reproduction/repo
 
       - name: Check Docker and Dockerfile availability
         id: check-docker
         run: |
           has_docker=false
           has_dockerfile=false
-          if docker info > /dev/null 2>&1; then has_docker=true; fi
-          if [ -f "$RUN_DIR/Dockerfile" ]; then has_dockerfile=true; fi
+
+          if docker info > /dev/null 2>&1; then
+            has_docker=true
+            echo "Docker is available"
+          else
+            echo "Docker is not available, will use native execution"
+          fi
+
+          if [ -f "Dockerfile" ]; then
+            has_dockerfile=true
+            echo "Dockerfile found"
+          else
+            echo "Dockerfile not found"
+          fi
+
           echo "has_docker=$has_docker" >> "$GITHUB_OUTPUT"
           echo "has_dockerfile=$has_dockerfile" >> "$GITHUB_OUTPUT"
 
       - name: Prepare results dir
-        run: mkdir -p "$RUN_DIR/$RESULTS_DIR"
+        run: mkdir -p "$RESULTS_DIR"
 
       - name: Build Docker image
         if: steps.check-docker.outputs.has_docker == 'true' && steps.check-docker.outputs.has_dockerfile == 'true'
         id: build-docker
         continue-on-error: true
-        run: |
-          (
-            set -e
-            echo "=== [DOCKER BUILD] Start at $(date -u) ==="
-            docker build -t airas-repro:latest "$RUN_DIR"
-            echo "=== [DOCKER BUILD] Success at $(date -u) ==="
-          ) 2>&1 | tee -a "$RUN_DIR/$RESULTS_DIR/run.log"
+        uses: Wandalen/wretry.action@v3
+        with:
+          attempt_limit: 3
+          attempt_delay: 30000
+          command: |
+            (
+              set -e
+              echo "=== [DOCKER BUILD] Start at $(date -u) ==="
+              docker build -t airas-repro:latest .
+              echo "=== [DOCKER BUILD] Success at $(date -u) ==="
+            ) 2>&1 | tee -a "$RESULTS_DIR/docker_build.log"
+
+            exit_status=${PIPESTATUS[0]}
+            if [ $exit_status -ne 0 ]; then
+              echo "::warning::Docker build failed (exit $exit_status), will fall back to native execution"
+              cat "$RESULTS_DIR/docker_build.log" >> "$RESULTS_DIR/run.log"
+              exit $exit_status
+            fi
 
       - name: Install uv (fallback if no Docker)
         if: steps.check-docker.outputs.has_docker == 'false' || steps.check-docker.outputs.has_dockerfile == 'false' || steps.build-docker.outcome != 'success'
-        uses: astral-sh/setup-uv@v6
+        uses: Wandalen/wretry.action@v3
         with:
-          python-version: "3.11"
+          action: astral-sh/setup-uv@v6
+          with: |
+            python-version: "3.11"
+          attempt_limit: 3
+          attempt_delay: 30000
 
       - name: Run reproduction (Docker)
         if: steps.check-docker.outputs.has_docker == 'true' && steps.check-docker.outputs.has_dockerfile == 'true' && steps.build-docker.outcome == 'success'
         id: run-docker
         continue-on-error: true
-        run: |
-          GPU_FLAGS=""
-          if nvidia-smi > /dev/null 2>&1; then GPU_FLAGS="--gpus all"; fi
-          docker run --rm $GPU_FLAGS \
-            -v "$(pwd)/$RUN_DIR/$RESULTS_DIR:/workspace/$RESULTS_DIR" \
-            -e ANTHROPIC_API_KEY -e AWS_BEARER_TOKEN_BEDROCK -e GEMINI_API_KEY -e HF_TOKEN \
-            -e OPENAI_API_KEY -e OPENROUTER_API_KEY -e WANDB_API_KEY \
-            airas-repro:latest \
-            bash -c '
-              set -e
-              echo "=== [REPRODUCE] Start at $(date -u) ==="
-              python -u -m src.main run=reproduction results_dir="'"$RESULTS_DIR"'"
-              echo "=== [REPRODUCE] PASSED at $(date -u) ==="
-            ' 2>&1 | tee -a "$RUN_DIR/$RESULTS_DIR/run.log"
+        uses: Wandalen/wretry.action@v3
+        with:
+          attempt_limit: 2
+          attempt_delay: 60000
+          command: |
+            trap 'sleep 1' EXIT
+
+            GPU_FLAGS=""
+            if nvidia-smi > /dev/null 2>&1; then
+              echo "GPU detected, enabling GPU support"
+              GPU_FLAGS="--gpus all"
+            else
+              echo "No GPU detected, running without GPU support"
+            fi
+
+            docker run --rm $GPU_FLAGS \
+              -v "$(pwd)/$RESULTS_DIR:/workspace/$RESULTS_DIR" \
+              -e ANTHROPIC_API_KEY \
+              -e AWS_BEARER_TOKEN_BEDROCK \
+              -e GEMINI_API_KEY \
+              -e HF_TOKEN \
+              -e LANGFUSE_BASE_URL \
+              -e LANGFUSE_PUBLIC_KEY \
+              -e LANGFUSE_SECRET_KEY \
+              -e OPENAI_API_KEY \
+              -e OPENROUTER_API_KEY \
+              -e WANDB_API_KEY \
+              airas-repro:latest \
+              bash -c '
+                set -e
+                set -o pipefail
+                echo "=== [REPRODUCE] Start at $(date -u) ==="
+                python -u -m src.main run=reproduction results_dir="'"$RESULTS_DIR"'"
+                echo "=== [REPRODUCE] PASSED at $(date -u) ==="
+              ' > >(tee -a "$RESULTS_DIR/run.log") 2>&1
 
       - name: Run reproduction (native)
         if: steps.check-docker.outputs.has_docker == 'false' || steps.check-docker.outputs.has_dockerfile == 'false' || steps.build-docker.outcome != 'success'
         id: run-native
         continue-on-error: true
-        run: |
-          set -eu
-          cd "$RUN_DIR"
-          uv venv .venv
-          uv pip install --no-cache --python .venv/bin/python hydra-core
-          if [ -f repo/requirements.txt ]; then
-            uv pip install --no-cache --python .venv/bin/python -r repo/requirements.txt 2>&1 | tee -a "$RESULTS_DIR/run.log" || true
-          fi
-          uv pip install --no-cache --python .venv/bin/python -e repo 2>/dev/null || true
-          if [ -f requirements.txt ]; then
-            uv pip install --no-cache --python .venv/bin/python -r requirements.txt 2>&1 | tee -a "$RESULTS_DIR/run.log" || true
-          fi
-          echo "=== [REPRODUCE] Start at $(date -u) ===" | tee -a "$RESULTS_DIR/run.log"
-          .venv/bin/python -u -m src.main run=reproduction results_dir="$RESULTS_DIR" 2>&1 | tee -a "$RESULTS_DIR/run.log"
-          echo "=== [REPRODUCE] PASSED at $(date -u) ===" | tee -a "$RESULTS_DIR/run.log"
+        uses: Wandalen/wretry.action@v3
+        with:
+          attempt_limit: 2
+          attempt_delay: 60000
+          command: |
+            trap 'sleep 1' EXIT
+            (
+              set -e
+              set -o pipefail
+              uv venv .venv
+              uv pip install --no-cache --python .venv/bin/python hydra-core
+              if [ -f .reproduction/repo/requirements.txt ]; then
+                uv pip install --no-cache --python .venv/bin/python -r .reproduction/repo/requirements.txt || true
+              fi
+              uv pip install --no-cache --python .venv/bin/python -e .reproduction/repo 2>/dev/null || true
+              if [ -f requirements.txt ]; then
+                uv pip install --no-cache --python .venv/bin/python -r requirements.txt || true
+              fi
+              echo "=== [REPRODUCE] Start at $(date -u) ==="
+              .venv/bin/python -u -m src.main run=reproduction results_dir="$RESULTS_DIR"
+              echo "=== [REPRODUCE] PASSED at $(date -u) ==="
+            ) > >(tee -a "$RESULTS_DIR/run.log") 2>&1
 
       - name: Determine run outcome
         id: run-outcome
         if: always()
         run: |
           set -eu
-          OUT="$RUN_DIR/$RESULTS_DIR"
           outcome="${{ steps.run-docker.outcome }}${{ steps.run-native.outcome }}"
           STATUS="passed"
-          if [[ "$outcome" != *"success"* ]] || [ ! -f "$OUT/result.json" ]; then
+          if [[ "$outcome" != *"success"* ]] || [ ! -f "$RESULTS_DIR/result.json" ]; then
             STATUS="failed"
-          elif [ ! -f "$OUT/repro.png" ] && [ ! -f "$OUT/repro.md" ]; then
+          elif [ ! -f "$RESULTS_DIR/repro.png" ] && [ ! -f "$RESULTS_DIR/repro.md" ]; then
             STATUS="failed"
           fi
           echo "status=$STATUS" >> "$GITHUB_OUTPUT"
 
-      # Backup/debug copy of the outputs as an artifact (matching the experiment workflows). The
-      # authoritative copy for fetch_paper_reproduction_results is the git commit below.
+      # Backup/debug copy; the authoritative copy for fetch_paper_reproduction_results is the git commit.
       - name: Upload results
         if: always()
         uses: Wandalen/wretry.action@v3
         with:
           action: actions/upload-artifact@v4
           with: |
-            name: paper-reproduction-${{ github.run_id }}-${{ github.event.inputs.run_id }}
-            path: ${{ env.RUN_DIR }}/${{ env.RESULTS_DIR }}
+            name: paper-reproduction-${{ github.run_id }}
+            path: ${{ env.RESULTS_DIR }}
             if-no-files-found: warn
           attempt_limit: 3
           attempt_delay: 30000
@@ -188,10 +231,10 @@ jobs:
           git config --local user.name "github-actions[bot]"
           git config --local user.email "github-actions[bot]@users.noreply.github.com"
           git remote set-url origin "https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}"
-          git add -- "$RUN_DIR"
+          git add -A -- .reproduction/results
 
           if ! git diff --staged --quiet; then
-            git commit -m "[CI] Paper reproduction run for run_id=$RUN_ID"
+            git commit -m "[CI] Paper reproduction run results"
             git checkout -- .
             for i in {1..5}; do
               git pull --rebase -X theirs origin "$BRANCH_NAME"
@@ -200,7 +243,7 @@ jobs:
               sleep $((2**i))
             done
           else
-            echo "No results to commit for run_id=$RUN_ID"
+            echo "No results to commit."
           fi
 
       - name: Fail job if run did not produce results

--- a/.github/workflows/run_parameter_tuning_run.yml
+++ b/.github/workflows/run_parameter_tuning_run.yml
@@ -8,6 +8,9 @@ on:
         description: 'Branch name (e.g., main)'
         required: true
         default: 'main'
+      repro_id:
+        description: 'Reproduction ID (directory name under .reproduction/)'
+        required: true
       repo_url:
         description: "GitHub URL of the paper's implementation repository (same as the reproduction)"
         required: false
@@ -31,7 +34,9 @@ defaults:
     shell: bash
 
 env:
-  RESULTS_DIR: .reproduction/tuning
+  REPRO_DIR: .reproduction/${{ github.event.inputs.repro_id }}
+  RESULTS_DIR: .reproduction/${{ github.event.inputs.repro_id }}/tuning
+  IMAGE_TAG: repro-${{ github.event.inputs.repro_id }}
 
 jobs:
   tune:
@@ -55,8 +60,8 @@ jobs:
       WANDB_API_KEY: ${{ secrets.WANDB_API_KEY }}
 
     steps:
-      # The checkout restores the reproduction (config/ + src/ + .reproduction/results/result.json),
-      # which run_paper_reproduction_run.yml committed to this branch.
+      # The checkout restores the reproduction (<repro_dir>/config/ + <repro_dir>/src/ +
+      # <repro_dir>/results/result.json), which run_paper_reproduction_run.yml committed to this branch.
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
@@ -65,8 +70,8 @@ jobs:
       - name: Validate reproduction code
         run: |
           set -eu
-          if [ ! -f "src/main.py" ] || [ ! -f "config/config.yaml" ] || [ ! -f ".reproduction/results/result.json" ]; then
-            echo "::error::src/main.py, config/config.yaml, or .reproduction/results/result.json is missing on this branch. The reproduction run must have completed and pushed first."
+          if [ ! -f "$REPRO_DIR/src/main.py" ] || [ ! -f "$REPRO_DIR/config/config.yaml" ] || [ ! -f "$REPRO_DIR/results/result.json" ]; then
+            echo "::error::$REPRO_DIR/src/main.py, $REPRO_DIR/config/config.yaml, or $REPRO_DIR/results/result.json is missing on this branch. The reproduction run must have completed with this repro_id first."
             exit 1
           fi
           if [ ! -f ".github/scripts/paper_reproduction/tune_driver.py" ]; then
@@ -74,12 +79,12 @@ jobs:
             exit 1
           fi
 
-      # .reproduction/repo is gitignored, so it must be re-cloned here.
+      # <repro_dir>/repo is gitignored, so it must be re-cloned here.
       - name: Re-clone target paper repository
         if: github.event.inputs.repo_url != ''
         run: |
           set -eu
-          git clone --depth 1 -- "$REPO_URL" .reproduction/repo
+          git clone --depth 1 -- "$REPO_URL" "$REPRO_DIR/repo"
 
       - name: Check Docker and Dockerfile availability
         id: check-docker
@@ -94,11 +99,11 @@ jobs:
             echo "Docker is not available, will use native execution"
           fi
 
-          if [ -f "Dockerfile" ]; then
+          if [ -f "$REPRO_DIR/Dockerfile" ]; then
             has_dockerfile=true
-            echo "Dockerfile found"
+            echo "Dockerfile found in $REPRO_DIR"
           else
-            echo "Dockerfile not found"
+            echo "Dockerfile not found in $REPRO_DIR"
           fi
 
           echo "has_docker=$has_docker" >> "$GITHUB_OUTPUT"
@@ -119,7 +124,7 @@ jobs:
             (
               set -e
               echo "=== [DOCKER BUILD] Start at $(date -u) ==="
-              docker build -t airas-repro:latest .
+              docker build -t "airas-repro:${IMAGE_TAG,,}" "$REPRO_DIR"
               echo "=== [DOCKER BUILD] Success at $(date -u) ==="
             ) 2>&1 | tee -a "$RESULTS_DIR/docker_build.log"
 
@@ -177,14 +182,14 @@ jobs:
               -e OPENAI_API_KEY \
               -e OPENROUTER_API_KEY \
               -e WANDB_API_KEY \
-              airas-repro:latest \
+              "airas-repro:${IMAGE_TAG,,}" \
               bash -c '
                 set -e
                 set -o pipefail
                 pip install -q optuna matplotlib pyyaml
                 echo "=== [TUNING] Start at $(date -u) ==="
                 python .github/scripts/paper_reproduction/tune_driver.py \
-                  --original-run-dir . \
+                  --original-run-dir "'"$REPRO_DIR"'" \
                   --tune-output-dir "'"$RESULTS_DIR"'" \
                   --python python \
                   '"$N_TRIALS_ARG"'
@@ -206,20 +211,20 @@ jobs:
               set -o pipefail
               uv venv .venv
               uv pip install --no-cache --python .venv/bin/python hydra-core optuna matplotlib pyyaml
-              if [ -f .reproduction/repo/requirements.txt ]; then
-                uv pip install --no-cache --python .venv/bin/python -r .reproduction/repo/requirements.txt || true
+              if [ -f "$REPRO_DIR/repo/requirements.txt" ]; then
+                uv pip install --no-cache --python .venv/bin/python -r "$REPRO_DIR/repo/requirements.txt" || true
               fi
-              uv pip install --no-cache --python .venv/bin/python -e .reproduction/repo 2>/dev/null || true
-              if [ -f requirements.txt ]; then
-                uv pip install --no-cache --python .venv/bin/python -r requirements.txt || true
+              uv pip install --no-cache --python .venv/bin/python -e "$REPRO_DIR/repo" 2>/dev/null || true
+              if [ -f "$REPRO_DIR/requirements.txt" ]; then
+                uv pip install --no-cache --python .venv/bin/python -r "$REPRO_DIR/requirements.txt" || true
               fi
               N_TRIALS_ARG=""
               if [ -n "${N_TRIALS:-}" ]; then N_TRIALS_ARG="--n-trials $N_TRIALS"; fi
               echo "=== [TUNING] Start at $(date -u) ==="
               .venv/bin/python .github/scripts/paper_reproduction/tune_driver.py \
-                --original-run-dir . \
+                --original-run-dir "$REPRO_DIR" \
                 --tune-output-dir "$RESULTS_DIR" \
-                --python .venv/bin/python \
+                --python "$(pwd)/.venv/bin/python" \
                 $N_TRIALS_ARG
               echo "=== [TUNING] PASSED at $(date -u) ==="
             ) > >(tee -a "$RESULTS_DIR/run.log") 2>&1
@@ -243,7 +248,7 @@ jobs:
         with:
           action: actions/upload-artifact@v4
           with: |
-            name: paper-tuning-${{ github.run_id }}
+            name: paper-tuning-${{ github.event.inputs.repro_id }}-${{ github.run_id }}
             path: ${{ env.RESULTS_DIR }}
             if-no-files-found: warn
           attempt_limit: 3
@@ -255,7 +260,7 @@ jobs:
           git config --local user.name "github-actions[bot]"
           git config --local user.email "github-actions[bot]@users.noreply.github.com"
           git remote set-url origin "https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}"
-          git add -A -- .reproduction/tuning
+          git add -A -- "$RESULTS_DIR"
 
           if ! git diff --staged --quiet; then
             git commit -m "[CI] Parameter tuning run results"

--- a/.github/workflows/run_parameter_tuning_run.yml
+++ b/.github/workflows/run_parameter_tuning_run.yml
@@ -1,0 +1,147 @@
+name: "Run Parameter Tuning (run)"
+run-name: "🤖 Parameter Tuning run: ${{ inputs.tune_run_id }} (base ${{ inputs.original_run_id }})"
+
+on:
+  workflow_dispatch:
+    inputs:
+      branch_name:
+        description: "Branch name (e.g., main)"
+        required: true
+        default: "main"
+      tune_run_id:
+        description: "Newly assigned tuning job id"
+        required: true
+        type: string
+      original_run_id:
+        description: "The already-run reproduction job id to tune (must have committed src/main.py + config + result.json)"
+        required: true
+        type: string
+      repo_url:
+        description: "GitHub URL of the paper's implementation repository (same as the original job)"
+        required: false
+        type: string
+      n_trials:
+        description: "Optuna trials (empty: use objective.n_trials from the original result.json, default 20)"
+        required: false
+        type: string
+      runner_label:
+        description: 'Runner label (e.g., ["ubuntu-latest"], ["self-hosted", "gpu-runner"])'
+        required: true
+        default: '["ubuntu-latest"]'
+
+permissions:
+  id-token: write
+  contents: write
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  tune:
+    runs-on: ${{ fromJSON(inputs.runner_label) }}
+    timeout-minutes: 360
+    env:
+      BRANCH_NAME: ${{ inputs.branch_name }}
+      TUNE_RUN_ID: ${{ inputs.tune_run_id }}
+      ORIGINAL_RUN_ID: ${{ inputs.original_run_id }}
+      REPO_URL: ${{ inputs.repo_url }}
+      N_TRIALS: ${{ inputs.n_trials }}
+      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+      OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+      GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
+      HF_TOKEN: ${{ secrets.HF_TOKEN }}
+      WANDB_API_KEY: ${{ secrets.WANDB_API_KEY }}
+    steps:
+      # The checkout restores the original reproduction (jobs/<original_run_id>/src + config +
+      # result.json), which run_paper_reproduction_run.yml committed to this branch.
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.branch_name }}
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v6
+        with:
+          python-version: "3.11"
+
+      - name: Prepare directories
+        run: mkdir -p "jobs/$TUNE_RUN_ID/outputs"
+
+      - name: Validate original job directory
+        run: |
+          set -eu
+          if [ ! -f "jobs/$ORIGINAL_RUN_ID/src/main.py" ] || [ ! -f "jobs/$ORIGINAL_RUN_ID/config/config.yaml" ] || [ ! -f "jobs/$ORIGINAL_RUN_ID/outputs/result.json" ]; then
+            echo "::error::jobs/$ORIGINAL_RUN_ID/{src/main.py,config/config.yaml,outputs/result.json} is missing on this branch. The reproduction run for original_run_id=$ORIGINAL_RUN_ID must have completed and pushed first."
+            exit 1
+          fi
+
+      # jobs/<original_run_id>/repo is gitignored, so it must be re-cloned here.
+      - name: Re-clone target paper repository
+        if: ${{ inputs.repo_url != '' }}
+        run: |
+          set -eu
+          git clone --depth 1 -- "$REPO_URL" "jobs/$ORIGINAL_RUN_ID/repo"
+
+      - name: Build environment and run tuning
+        id: run-tune
+        continue-on-error: true
+        run: |
+          set -eu
+          cd "jobs/$ORIGINAL_RUN_ID"
+          uv venv .venv
+          if [ -f repo/requirements.txt ]; then
+            uv pip install --no-cache --python .venv/bin/python -r repo/requirements.txt || true
+          fi
+          uv pip install --no-cache --python .venv/bin/python -e repo 2>/dev/null || true
+          if [ -f outputs/requirements.txt ]; then
+            uv pip install --no-cache --python .venv/bin/python -r outputs/requirements.txt || true
+          fi
+          uv pip install --no-cache --python .venv/bin/python optuna matplotlib pyyaml hydra-core
+          cd "$GITHUB_WORKSPACE"
+          N_TRIALS_ARG=""
+          if [ -n "${N_TRIALS:-}" ]; then N_TRIALS_ARG="--n-trials $N_TRIALS"; fi
+          "jobs/$ORIGINAL_RUN_ID/.venv/bin/python" .github/scripts/paper_reproduction/tune_driver.py \
+            --original-job-dir "jobs/$ORIGINAL_RUN_ID" \
+            --tune-output-dir "jobs/$TUNE_RUN_ID/outputs" \
+            --python .venv/bin/python \
+            $N_TRIALS_ARG 2>&1 | tee "jobs/$TUNE_RUN_ID/outputs/run.log"
+
+      - name: Determine tuning outcome
+        id: tuning-outcome
+        if: always()
+        run: |
+          set -eu
+          OUT="jobs/$TUNE_RUN_ID/outputs"
+          STATUS="passed"
+          if [ "${{ steps.run-tune.outcome }}" != "success" ] || [ ! -f "$OUT/result.json" ] || [ ! -f "$OUT/tuning_figure.png" ]; then
+            STATUS="failed"
+          fi
+          echo "status=$STATUS" >> "$GITHUB_OUTPUT"
+
+      - name: Commit and push results
+        if: always()
+        run: |
+          git config --local user.name "github-actions[bot]"
+          git config --local user.email "github-actions[bot]@users.noreply.github.com"
+          git remote set-url origin "https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}"
+          git add -- "jobs/$TUNE_RUN_ID"
+
+          if ! git diff --staged --quiet; then
+            git commit -m "[CI] Parameter tuning run for tune_run_id=$TUNE_RUN_ID"
+            git checkout -- .
+            for i in {1..5}; do
+              git pull --rebase -X theirs origin "$BRANCH_NAME"
+              git push origin "HEAD:$BRANCH_NAME" && break
+              echo "Push failed on attempt $i. Retrying in $((2**i)) seconds..."
+              sleep $((2**i))
+            done
+          else
+            echo "No results to commit for tune_run_id=$TUNE_RUN_ID"
+          fi
+
+      - name: Fail job if tuning did not produce results
+        if: ${{ steps.tuning-outcome.outputs.status == 'failed' }}
+        run: |
+          echo "::error::tune_driver.py did not produce result.json + tuning_figure.png. See outputs/run.log."
+          exit 1

--- a/.github/workflows/run_parameter_tuning_run.yml
+++ b/.github/workflows/run_parameter_tuning_run.yml
@@ -1,29 +1,21 @@
 name: "Run Parameter Tuning (run)"
-run-name: "🤖 Parameter Tuning run: ${{ inputs.tune_run_id }} (base ${{ inputs.original_run_id }})"
+run-name: "🤖 Parameter Tuning run"
 
 on:
   workflow_dispatch:
     inputs:
       branch_name:
-        description: "Branch name (e.g., main)"
+        description: 'Branch name (e.g., main)'
         required: true
-        default: "main"
-      tune_run_id:
-        description: "Newly assigned tuning job id"
-        required: true
-        type: string
-      original_run_id:
-        description: "The already-run reproduction job id to tune (must have committed src/main.py + config + result.json)"
-        required: true
-        type: string
+        default: 'main'
       repo_url:
-        description: "GitHub URL of the paper's implementation repository (same as the original job)"
+        description: "GitHub URL of the paper's implementation repository (same as the reproduction)"
         required: false
-        type: string
+        default: ''
       n_trials:
-        description: "Optuna trials (empty: use objective.n_trials from the original result.json, default 20)"
+        description: 'Optuna trials (empty: use optuna.n_trials from the config, default 20)'
         required: false
-        type: string
+        default: ''
       runner_label:
         description: 'Runner label (e.g., ["ubuntu-latest"], ["self-hosted", "gpu-runner"])'
         required: true
@@ -32,92 +24,230 @@ on:
 permissions:
   id-token: write
   contents: write
+  actions: write
 
 defaults:
   run:
     shell: bash
 
+env:
+  RESULTS_DIR: .reproduction/tuning
+
 jobs:
   tune:
-    runs-on: ${{ fromJSON(inputs.runner_label) }}
-    timeout-minutes: 360
+    name: Run Tuning
+    runs-on: ${{ fromJSON(github.event.inputs.runner_label) }}
+    timeout-minutes: 600
+
     env:
-      BRANCH_NAME: ${{ inputs.branch_name }}
-      TUNE_RUN_ID: ${{ inputs.tune_run_id }}
-      ORIGINAL_RUN_ID: ${{ inputs.original_run_id }}
-      REPO_URL: ${{ inputs.repo_url }}
-      N_TRIALS: ${{ inputs.n_trials }}
+      BRANCH_NAME: ${{ github.event.inputs.branch_name }}
+      REPO_URL: ${{ github.event.inputs.repo_url }}
+      N_TRIALS: ${{ github.event.inputs.n_trials }}
       ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
-      OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+      AWS_BEARER_TOKEN_BEDROCK: ${{ secrets.AWS_BEARER_TOKEN_BEDROCK }}
       GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
       HF_TOKEN: ${{ secrets.HF_TOKEN }}
+      LANGFUSE_BASE_URL: ${{ secrets.LANGFUSE_BASE_URL }}
+      LANGFUSE_PUBLIC_KEY: ${{ secrets.LANGFUSE_PUBLIC_KEY }}
+      LANGFUSE_SECRET_KEY: ${{ secrets.LANGFUSE_SECRET_KEY }}
+      OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+      OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
       WANDB_API_KEY: ${{ secrets.WANDB_API_KEY }}
+
     steps:
-      # The checkout restores the original reproduction (jobs/<original_run_id>/src + config +
-      # result.json), which run_paper_reproduction_run.yml committed to this branch.
+      # The checkout restores the reproduction (config/ + src/ + .reproduction/results/result.json),
+      # which run_paper_reproduction_run.yml committed to this branch.
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
-          ref: ${{ inputs.branch_name }}
+          ref: ${{ github.event.inputs.branch_name }}
 
-      - name: Install uv
-        uses: astral-sh/setup-uv@v6
-        with:
-          python-version: "3.11"
-
-      - name: Prepare directories
-        run: mkdir -p "jobs/$TUNE_RUN_ID/outputs"
-
-      - name: Validate original job directory
+      - name: Validate reproduction code
         run: |
           set -eu
-          if [ ! -f "jobs/$ORIGINAL_RUN_ID/src/main.py" ] || [ ! -f "jobs/$ORIGINAL_RUN_ID/config/config.yaml" ] || [ ! -f "jobs/$ORIGINAL_RUN_ID/outputs/result.json" ]; then
-            echo "::error::jobs/$ORIGINAL_RUN_ID/{src/main.py,config/config.yaml,outputs/result.json} is missing on this branch. The reproduction run for original_run_id=$ORIGINAL_RUN_ID must have completed and pushed first."
+          if [ ! -f "src/main.py" ] || [ ! -f "config/config.yaml" ] || [ ! -f ".reproduction/results/result.json" ]; then
+            echo "::error::src/main.py, config/config.yaml, or .reproduction/results/result.json is missing on this branch. The reproduction run must have completed and pushed first."
+            exit 1
+          fi
+          if [ ! -f ".github/scripts/paper_reproduction/tune_driver.py" ]; then
+            echo "::error::.github/scripts/paper_reproduction/tune_driver.py is missing."
             exit 1
           fi
 
-      # jobs/<original_run_id>/repo is gitignored, so it must be re-cloned here.
+      # .reproduction/repo is gitignored, so it must be re-cloned here.
       - name: Re-clone target paper repository
-        if: ${{ inputs.repo_url != '' }}
+        if: github.event.inputs.repo_url != ''
         run: |
           set -eu
-          git clone --depth 1 -- "$REPO_URL" "jobs/$ORIGINAL_RUN_ID/repo"
+          git clone --depth 1 -- "$REPO_URL" .reproduction/repo
 
-      - name: Build environment and run tuning
-        id: run-tune
-        continue-on-error: true
+      - name: Check Docker and Dockerfile availability
+        id: check-docker
         run: |
-          set -eu
-          cd "jobs/$ORIGINAL_RUN_ID"
-          uv venv .venv
-          if [ -f repo/requirements.txt ]; then
-            uv pip install --no-cache --python .venv/bin/python -r repo/requirements.txt || true
+          has_docker=false
+          has_dockerfile=false
+
+          if docker info > /dev/null 2>&1; then
+            has_docker=true
+            echo "Docker is available"
+          else
+            echo "Docker is not available, will use native execution"
           fi
-          uv pip install --no-cache --python .venv/bin/python -e repo 2>/dev/null || true
-          if [ -f outputs/requirements.txt ]; then
-            uv pip install --no-cache --python .venv/bin/python -r outputs/requirements.txt || true
+
+          if [ -f "Dockerfile" ]; then
+            has_dockerfile=true
+            echo "Dockerfile found"
+          else
+            echo "Dockerfile not found"
           fi
-          uv pip install --no-cache --python .venv/bin/python optuna matplotlib pyyaml hydra-core
-          cd "$GITHUB_WORKSPACE"
-          N_TRIALS_ARG=""
-          if [ -n "${N_TRIALS:-}" ]; then N_TRIALS_ARG="--n-trials $N_TRIALS"; fi
-          "jobs/$ORIGINAL_RUN_ID/.venv/bin/python" .github/scripts/paper_reproduction/tune_driver.py \
-            --original-job-dir "jobs/$ORIGINAL_RUN_ID" \
-            --tune-output-dir "jobs/$TUNE_RUN_ID/outputs" \
-            --python .venv/bin/python \
-            $N_TRIALS_ARG 2>&1 | tee "jobs/$TUNE_RUN_ID/outputs/run.log"
+
+          echo "has_docker=$has_docker" >> "$GITHUB_OUTPUT"
+          echo "has_dockerfile=$has_dockerfile" >> "$GITHUB_OUTPUT"
+
+      - name: Prepare tuning directory
+        run: mkdir -p "$RESULTS_DIR"
+
+      - name: Build Docker image
+        if: steps.check-docker.outputs.has_docker == 'true' && steps.check-docker.outputs.has_dockerfile == 'true'
+        id: build-docker
+        continue-on-error: true
+        uses: Wandalen/wretry.action@v3
+        with:
+          attempt_limit: 3
+          attempt_delay: 30000
+          command: |
+            (
+              set -e
+              echo "=== [DOCKER BUILD] Start at $(date -u) ==="
+              docker build -t airas-repro:latest .
+              echo "=== [DOCKER BUILD] Success at $(date -u) ==="
+            ) 2>&1 | tee -a "$RESULTS_DIR/docker_build.log"
+
+            exit_status=${PIPESTATUS[0]}
+            if [ $exit_status -ne 0 ]; then
+              echo "::warning::Docker build failed (exit $exit_status), will fall back to native execution"
+              cat "$RESULTS_DIR/docker_build.log" >> "$RESULTS_DIR/run.log"
+              exit $exit_status
+            fi
+
+      - name: Install uv (fallback if no Docker)
+        if: steps.check-docker.outputs.has_docker == 'false' || steps.check-docker.outputs.has_dockerfile == 'false' || steps.build-docker.outcome != 'success'
+        uses: Wandalen/wretry.action@v3
+        with:
+          action: astral-sh/setup-uv@v6
+          with: |
+            python-version: "3.11"
+          attempt_limit: 3
+          attempt_delay: 30000
+
+      # Bind-mount the whole workspace so tune_driver.py (.github/scripts) and trial outputs are visible.
+      # Optuna/matplotlib are installed at run time (not part of the reproduction Dockerfile).
+      - name: Run tuning (Docker)
+        if: steps.check-docker.outputs.has_docker == 'true' && steps.check-docker.outputs.has_dockerfile == 'true' && steps.build-docker.outcome == 'success'
+        id: run-docker
+        continue-on-error: true
+        uses: Wandalen/wretry.action@v3
+        with:
+          attempt_limit: 2
+          attempt_delay: 60000
+          command: |
+            trap 'sleep 1' EXIT
+
+            GPU_FLAGS=""
+            if nvidia-smi > /dev/null 2>&1; then
+              echo "GPU detected, enabling GPU support"
+              GPU_FLAGS="--gpus all"
+            else
+              echo "No GPU detected, running without GPU support"
+            fi
+
+            N_TRIALS_ARG=""
+            if [ -n "${N_TRIALS:-}" ]; then N_TRIALS_ARG="--n-trials $N_TRIALS"; fi
+
+            docker run --rm $GPU_FLAGS \
+              -v "$(pwd):/workspace" \
+              -w /workspace \
+              -e ANTHROPIC_API_KEY \
+              -e AWS_BEARER_TOKEN_BEDROCK \
+              -e GEMINI_API_KEY \
+              -e HF_TOKEN \
+              -e LANGFUSE_BASE_URL \
+              -e LANGFUSE_PUBLIC_KEY \
+              -e LANGFUSE_SECRET_KEY \
+              -e OPENAI_API_KEY \
+              -e OPENROUTER_API_KEY \
+              -e WANDB_API_KEY \
+              airas-repro:latest \
+              bash -c '
+                set -e
+                set -o pipefail
+                pip install -q optuna matplotlib pyyaml
+                echo "=== [TUNING] Start at $(date -u) ==="
+                python .github/scripts/paper_reproduction/tune_driver.py \
+                  --original-run-dir . \
+                  --tune-output-dir "'"$RESULTS_DIR"'" \
+                  --python python \
+                  '"$N_TRIALS_ARG"'
+                echo "=== [TUNING] PASSED at $(date -u) ==="
+              ' > >(tee -a "$RESULTS_DIR/run.log") 2>&1
+
+      - name: Run tuning (native)
+        if: steps.check-docker.outputs.has_docker == 'false' || steps.check-docker.outputs.has_dockerfile == 'false' || steps.build-docker.outcome != 'success'
+        id: run-native
+        continue-on-error: true
+        uses: Wandalen/wretry.action@v3
+        with:
+          attempt_limit: 2
+          attempt_delay: 60000
+          command: |
+            trap 'sleep 1' EXIT
+            (
+              set -e
+              set -o pipefail
+              uv venv .venv
+              uv pip install --no-cache --python .venv/bin/python hydra-core optuna matplotlib pyyaml
+              if [ -f .reproduction/repo/requirements.txt ]; then
+                uv pip install --no-cache --python .venv/bin/python -r .reproduction/repo/requirements.txt || true
+              fi
+              uv pip install --no-cache --python .venv/bin/python -e .reproduction/repo 2>/dev/null || true
+              if [ -f requirements.txt ]; then
+                uv pip install --no-cache --python .venv/bin/python -r requirements.txt || true
+              fi
+              N_TRIALS_ARG=""
+              if [ -n "${N_TRIALS:-}" ]; then N_TRIALS_ARG="--n-trials $N_TRIALS"; fi
+              echo "=== [TUNING] Start at $(date -u) ==="
+              .venv/bin/python .github/scripts/paper_reproduction/tune_driver.py \
+                --original-run-dir . \
+                --tune-output-dir "$RESULTS_DIR" \
+                --python .venv/bin/python \
+                $N_TRIALS_ARG
+              echo "=== [TUNING] PASSED at $(date -u) ==="
+            ) > >(tee -a "$RESULTS_DIR/run.log") 2>&1
 
       - name: Determine tuning outcome
         id: tuning-outcome
         if: always()
         run: |
           set -eu
-          OUT="jobs/$TUNE_RUN_ID/outputs"
+          outcome="${{ steps.run-docker.outcome }}${{ steps.run-native.outcome }}"
           STATUS="passed"
-          if [ "${{ steps.run-tune.outcome }}" != "success" ] || [ ! -f "$OUT/result.json" ] || [ ! -f "$OUT/tuning_figure.png" ]; then
+          if [[ "$outcome" != *"success"* ]] || [ ! -f "$RESULTS_DIR/result.json" ] || [ ! -f "$RESULTS_DIR/tuning_figure.png" ]; then
             STATUS="failed"
           fi
           echo "status=$STATUS" >> "$GITHUB_OUTPUT"
+
+      # Backup/debug copy; the authoritative copy for fetch_parameter_tuning_results is the git commit.
+      - name: Upload results
+        if: always()
+        uses: Wandalen/wretry.action@v3
+        with:
+          action: actions/upload-artifact@v4
+          with: |
+            name: paper-tuning-${{ github.run_id }}
+            path: ${{ env.RESULTS_DIR }}
+            if-no-files-found: warn
+          attempt_limit: 3
+          attempt_delay: 30000
 
       - name: Commit and push results
         if: always()
@@ -125,10 +255,10 @@ jobs:
           git config --local user.name "github-actions[bot]"
           git config --local user.email "github-actions[bot]@users.noreply.github.com"
           git remote set-url origin "https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}"
-          git add -- "jobs/$TUNE_RUN_ID"
+          git add -A -- .reproduction/tuning
 
           if ! git diff --staged --quiet; then
-            git commit -m "[CI] Parameter tuning run for tune_run_id=$TUNE_RUN_ID"
+            git commit -m "[CI] Parameter tuning run results"
             git checkout -- .
             for i in {1..5}; do
               git pull --rebase -X theirs origin "$BRANCH_NAME"
@@ -137,11 +267,11 @@ jobs:
               sleep $((2**i))
             done
           else
-            echo "No results to commit for tune_run_id=$TUNE_RUN_ID"
+            echo "No results to commit."
           fi
 
       - name: Fail job if tuning did not produce results
-        if: ${{ steps.tuning-outcome.outputs.status == 'failed' }}
+        if: steps.tuning-outcome.outputs.status == 'failed'
         run: |
-          echo "::error::tune_driver.py did not produce result.json + tuning_figure.png. See outputs/run.log."
+          echo "::error::tune_driver.py did not produce result.json + tuning_figure.png. See $RESULTS_DIR/run.log."
           exit 1

--- a/.gitignore
+++ b/.gitignore
@@ -198,4 +198,4 @@ models/
 *.blg
 
 # .reproduction/ are committed by the workflows; the cloned paper repo is not.
-.reproduction/repo/
+.reproduction/*/repo/

--- a/.gitignore
+++ b/.gitignore
@@ -196,3 +196,6 @@ models/
 *.log
 *.out
 *.blg
+
+# .reproduction/ are committed by the workflows; the cloned paper repo is not.
+.reproduction/repo/

--- a/.gitignore
+++ b/.gitignore
@@ -197,5 +197,6 @@ models/
 *.out
 *.blg
 
-# .reproduction/ are committed by the workflows; the cloned paper repo is not.
+# .reproduction/ are committed by the workflows; the cloned paper repo and paper source are not.
 .reproduction/*/repo/
+.reproduction/*/tex_src/


### PR DESCRIPTION
## Summary

  論文の実験を GitHub Actions 上で自動的に再現するワークフロー一式を追加する。

  - **generate**: エージェント（Claude Code / OpenCode）が論文 URL（arXiv の場合は TeX ソースも取得）を読み取り、
    Hydra 構成の再現コード（`config.yaml` / `run/reproduction.yaml` / `src/main.py`）を
    `.reproduction/<repro_id>/` 配下に生成してコミットする。`reproduction.yaml` は各パラメータの値を記載しており、監査エージェントが論文から抽出した値（`paper_extraction.json`）とクロスチェックする際にもこの値を利用する。
    エージェント自身は実験を実行しない。
  - **run**: 生成されたコードを実際に実行し、`result.json` と成果物（`repro.png` /
    `repro.md`）を生成してコミットする。Dockerfile があれば Docker、なければ `uv`
    によるネイティブ実行にフォールバックする。
  - **tune**: `run/reproduction.yaml` に宣言された Optuna 探索空間を読み、`tune_driver.py` が `src/main.py`
    を Hydra CLI オーバーライドで繰り返し実行してハイパーパラメータ探索を行う。
    `repro_id` により同一リポジトリ内で複数の再現を並行管理できる。

airasリポジトリのPR: https://github.com/airas-org/airas/pull/944
