### PR TITLE
feat: support Vercel AI Gateway models in OpenCode workflows

### DIFF
--- a/.github/actions/run-open-code/action.yml
+++ b/.github/actions/run-open-code/action.yml
@@ -3,7 +3,7 @@ description: "Setup OpenCode, resolve LLM provider, and run opencode with retry"
 
 inputs:
   model_name:
-    description: "Model name (e.g. openrouter/openai/gpt-5-nano)"
+    description: "Model name (e.g. openrouter/openai/gpt-5-nano, vercel/anthropic/claude-sonnet-4)"
     required: true
   prompt:
     description: "Prompt passed to opencode (ignored if prompt_file is provided)"
@@ -136,6 +136,17 @@ runs:
           openrouter/*)
             echo "PROVIDER=openrouter" >> "$GITHUB_ENV"
             echo "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}" >> "$GITHUB_ENV"
+            ;;
+
+          # Vercel AI Gateway fronts many vendors behind one key, so the
+          # model keeps its upstream vendor prefix after "vercel/"
+          # (e.g. vercel/anthropic/claude-sonnet-4). Match it before the
+          # bare vendor prefixes below.
+          vercel/*)
+            echo "PROVIDER=vercel" >> "$GITHUB_ENV"
+            # airas syncs the key under litellm's name; opencode reads
+            # AI_GATEWAY_API_KEY. Accept either.
+            echo "AI_GATEWAY_API_KEY=${AI_GATEWAY_API_KEY:-${VERCEL_AI_GATEWAY_API_KEY}}" >> "$GITHUB_ENV"
             ;;
 
           openai/*)

--- a/.github/workflows/compile_latex.yml
+++ b/.github/workflows/compile_latex.yml
@@ -28,7 +28,7 @@ on:
           - open_code
         default: 'claude_code'
       model_name:
-        description: 'Model to use (for OpenCode: openrouter/openai/gpt-5-nano, for Claude Code: sonnet/opus/haiku)'
+        description: 'Model to use (for OpenCode: openrouter/openai/gpt-5-nano or vercel/anthropic/claude-sonnet-4, for Claude Code: sonnet/opus/haiku)'
         required: true
         default: 'sonnet'
       # NOTE: Use prompt_path instead of passing prompt directly to avoid
@@ -142,6 +142,7 @@ jobs:
           LANGFUSE_BASEURL: ${{ secrets.LANGFUSE_BASE_URL }}
 
           OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
+          VERCEL_AI_GATEWAY_API_KEY: ${{ secrets.VERCEL_AI_GATEWAY_API_KEY }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           GOOGLE_API_KEY: ${{ secrets.GEMINI_API_KEY }}

--- a/.github/workflows/run_code_generator.yml
+++ b/.github/workflows/run_code_generator.yml
@@ -29,7 +29,7 @@ on:
           - open_code
         default: 'claude_code'
       model_name:
-        description: 'Model to use (for OpenCode: openrouter/openai/gpt-5-nano, for Claude Code: sonnet/opus/haiku)'
+        description: 'Model to use (for OpenCode: openrouter/openai/gpt-5-nano or vercel/anthropic/claude-sonnet-4, for Claude Code: sonnet/opus/haiku)'
         required: true
         default: 'sonnet'
       # NOTE: Use prompt_path instead of passing prompt directly to avoid
@@ -124,6 +124,7 @@ jobs:
           LANGFUSE_BASEURL: ${{ secrets.LANGFUSE_BASE_URL }}
 
           OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
+          VERCEL_AI_GATEWAY_API_KEY: ${{ secrets.VERCEL_AI_GATEWAY_API_KEY }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           GOOGLE_API_KEY: ${{ secrets.GEMINI_API_KEY }}

--- a/.github/workflows/run_diagram_generator.yml
+++ b/.github/workflows/run_diagram_generator.yml
@@ -25,7 +25,7 @@ on:
           - open_code
         default: 'claude_code'
       model_name:
-        description: 'Model to use (for OpenCode: openrouter/openai/gpt-5-nano, for Claude Code: sonnet/opus/haiku)'
+        description: 'Model to use (for OpenCode: openrouter/openai/gpt-5-nano or vercel/anthropic/claude-sonnet-4, for Claude Code: sonnet/opus/haiku)'
         required: true
         default: 'sonnet'
       prompt_path:
@@ -123,6 +123,7 @@ jobs:
           mcp_config: /tmp/mcp-config.json
         env:
           OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
+          VERCEL_AI_GATEWAY_API_KEY: ${{ secrets.VERCEL_AI_GATEWAY_API_KEY }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           GOOGLE_API_KEY: ${{ secrets.GEMINI_API_KEY }}

--- a/.github/workflows/run_experiment.yml
+++ b/.github/workflows/run_experiment.yml
@@ -56,6 +56,7 @@ jobs:
       LANGFUSE_SECRET_KEY: ${{ secrets.LANGFUSE_SECRET_KEY }}
       OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
       OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
+      VERCEL_AI_GATEWAY_API_KEY: ${{ secrets.VERCEL_AI_GATEWAY_API_KEY }}
       WANDB_API_KEY: ${{ secrets.WANDB_API_KEY }}
 
     steps:
@@ -151,6 +152,7 @@ jobs:
               -e LANGFUSE_SECRET_KEY \
               -e OPENAI_API_KEY \
               -e OPENROUTER_API_KEY \
+              -e VERCEL_AI_GATEWAY_API_KEY \
               -e WANDB_API_KEY \
               airas-experiment:latest \
               bash -c '

--- a/.github/workflows/run_experiment_validator.yml
+++ b/.github/workflows/run_experiment_validator.yml
@@ -45,7 +45,7 @@ on:
           - open_code
         default: 'claude_code'
       model_name:
-        description: 'Model to use (for OpenCode: openrouter/openai/gpt-5-nano, for Claude Code: sonnet/opus/haiku)'
+        description: 'Model to use (for OpenCode: openrouter/openai/gpt-5-nano or vercel/anthropic/claude-sonnet-4, for Claude Code: sonnet/opus/haiku)'
         required: true
         default: 'sonnet'
       # NOTE: Use prompt_path instead of passing prompt directly to avoid
@@ -216,6 +216,7 @@ jobs:
           LANGFUSE_BASEURL: ${{ secrets.LANGFUSE_BASE_URL }}
 
           OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
+          VERCEL_AI_GATEWAY_API_KEY: ${{ secrets.VERCEL_AI_GATEWAY_API_KEY }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           GOOGLE_API_KEY: ${{ secrets.GEMINI_API_KEY }}

--- a/.github/workflows/run_interactive_repo_agent.yml
+++ b/.github/workflows/run_interactive_repo_agent.yml
@@ -21,7 +21,7 @@ on:
           - open_code
         default: 'claude_code'
       model_name:
-        description: 'Model to use (for OpenCode: openrouter/openai/gpt-5-nano, for Claude Code: sonnet/opus/haiku)'
+        description: 'Model to use (for OpenCode: openrouter/openai/gpt-5-nano or vercel/anthropic/claude-sonnet-4, for Claude Code: sonnet/opus/haiku)'
         required: true
         default: 'sonnet'
       timeout_minutes:
@@ -111,6 +111,13 @@ jobs:
               echo "LLM_PROVIDER=openrouter" >> "$GITHUB_ENV"
               echo "OPENROUTER_API_KEY=${{ secrets.OPENROUTER_API_KEY }}" >> "$GITHUB_ENV"
               ;;
+            # Vercel AI Gateway keeps the upstream vendor prefix after
+            # "vercel/" (e.g. vercel/anthropic/claude-sonnet-4), so it must
+            # match before the bare vendor prefixes below.
+            vercel/*)
+              echo "LLM_PROVIDER=vercel" >> "$GITHUB_ENV"
+              echo "AI_GATEWAY_API_KEY=${{ secrets.VERCEL_AI_GATEWAY_API_KEY }}" >> "$GITHUB_ENV"
+              ;;
             openai/*)
               echo "LLM_PROVIDER=openai" >> "$GITHUB_ENV"
               echo "OPENAI_API_KEY=${{ secrets.OPENAI_API_KEY }}" >> "$GITHUB_ENV"
@@ -175,6 +182,7 @@ jobs:
           else
             # OpenCode: inject provider-specific env vars resolved in earlier step
             for VAR in OPENROUTER_API_KEY OPENAI_API_KEY ANTHROPIC_API_KEY GOOGLE_API_KEY \
+                       AI_GATEWAY_API_KEY \
                        AZURE_OPENAI_API_KEY AZURE_OPENAI_ENDPOINT AZURE_OPENAI_API_VERSION \
                        AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY AWS_DEFAULT_REGION; do
               VAL="${!VAR}"

--- a/.github/workflows/run_main_experiment.yml
+++ b/.github/workflows/run_main_experiment.yml
@@ -43,6 +43,7 @@ jobs:
       LANGFUSE_SECRET_KEY: ${{ secrets.LANGFUSE_SECRET_KEY }}
       OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
       OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
+      VERCEL_AI_GATEWAY_API_KEY: ${{ secrets.VERCEL_AI_GATEWAY_API_KEY }}
       WANDB_API_KEY: ${{ secrets.WANDB_API_KEY }}
 
     outputs:
@@ -142,6 +143,7 @@ jobs:
               -e LANGFUSE_SECRET_KEY \
               -e OPENAI_API_KEY \
               -e OPENROUTER_API_KEY \
+              -e VERCEL_AI_GATEWAY_API_KEY \
               -e WANDB_API_KEY \
               airas-experiment:latest \
               bash -c '

--- a/.github/workflows/run_sanity_check.yml
+++ b/.github/workflows/run_sanity_check.yml
@@ -47,6 +47,7 @@ jobs:
       LANGFUSE_SECRET_KEY: ${{ secrets.LANGFUSE_SECRET_KEY }}
       OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
       OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
+      VERCEL_AI_GATEWAY_API_KEY: ${{ secrets.VERCEL_AI_GATEWAY_API_KEY }}
       WANDB_API_KEY: ${{ secrets.WANDB_API_KEY }}
 
     steps:
@@ -143,6 +144,7 @@ jobs:
               -e LANGFUSE_SECRET_KEY \
               -e OPENAI_API_KEY \
               -e OPENROUTER_API_KEY \
+              -e VERCEL_AI_GATEWAY_API_KEY \
               -e WANDB_API_KEY \
               airas-experiment:latest \
               bash -c '

--- a/.github/workflows/run_verification_code_generator.yml
+++ b/.github/workflows/run_verification_code_generator.yml
@@ -33,7 +33,7 @@ on:
           - open_code
         default: 'claude_code'
       model_name:
-        description: 'Model to use (for OpenCode: openrouter/openai/gpt-5-nano, for Claude Code: sonnet/opus/haiku)'
+        description: 'Model to use (for OpenCode: openrouter/openai/gpt-5-nano or vercel/anthropic/claude-sonnet-4, for Claude Code: sonnet/opus/haiku)'
         required: true
         default: 'sonnet'
       prompt_path:
@@ -129,6 +129,7 @@ jobs:
           LANGFUSE_BASEURL: ${{ secrets.LANGFUSE_BASE_URL }}
 
           OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
+          VERCEL_AI_GATEWAY_API_KEY: ${{ secrets.VERCEL_AI_GATEWAY_API_KEY }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           GOOGLE_API_KEY: ${{ secrets.GEMINI_API_KEY }}


### PR DESCRIPTION
airas-org/airas#961 の open-code 側の対応です。airas 側の PR: airas-org/airas#965

## 概要

`model_name` に `vercel/<vendor>/<model>`（例: `vercel/anthropic/claude-sonnet-4`）を指定すると、Vercel AI Gateway 経由で OpenCode が動くようにします。Gateway の 1 キーで各ベンダのモデルに到達できるため、プロバイダごとにキーを用意する必要がなくなります。

OpenCode 側のプロバイダ ID は `vercel`、API キーの環境変数は `AI_GATEWAY_API_KEY` です（models.dev のプロバイダ定義に準拠）。

## 変更点

- **`.github/actions/run-open-code/action.yml`** — プロバイダ解決の `case` に `vercel/*` を追加し、`AI_GATEWAY_API_KEY` をエクスポート。airas はこのシークレットを litellm 準拠の `VERCEL_AI_GATEWAY_API_KEY` という名前で同期するため、`${AI_GATEWAY_API_KEY:-${VERCEL_AI_GATEWAY_API_KEY}}` として**どちらの名前でも動く**ようにしています。
- **`run_interactive_repo_agent.yml`** — 同じ解決をインラインの `case` にも追加し、tmux セッションへ注入する変数リストに `AI_GATEWAY_API_KEY` を追加。
- **OpenCode を起動する 5 ワークフロー** (`run_code_generator` / `run_diagram_generator` / `run_verification_code_generator` / `run_experiment_validator` / `compile_latex`) — `VERCEL_AI_GATEWAY_API_KEY` をリポジトリシークレットから渡す。
- **実験系 3 ワークフロー** (`run_main_experiment` / `run_experiment` / `run_sanity_check`) — 生成された研究コードが LLM を呼ぶ場合に備え、他プロバイダキーと同様に env と `docker run -e` へ追加。
- `model_name` の説明文に Gateway 形式の例を追記。

`vercel/*` の分岐は、`anthropic/*` などの素のベンダプレフィックスより**前**に置いています。Gateway のモデル名は `vercel/` の後ろに上流ベンダのプレフィックスを保持するためです。

## 検証

- 全ワークフロー / アクションの YAML パースを確認
- プロバイダ解決スクリプトを抽出して実行し、以下を確認:
  - `vercel/anthropic/claude-sonnet-4` → `PROVIDER=vercel`, `AI_GATEWAY_API_KEY=<VERCEL_AI_GATEWAY_API_KEY の値>` (exit 0)
  - `openrouter/openai/gpt-5-nano` → 従来どおり `PROVIDER=openrouter` (exit 0)
  - 未知のプレフィックス → exit 1

実キーでの Actions 実行は行っていないため、実運用での 1 周確認をお願いできると確実です。

---
_Generated by [Claude Code](https://claude.ai/code/session_01C7SYMcD4WC5Sz3XjwTJ6xY)_