### PR TITLE
feat: run OpenCode against the Rikyu API

### DIFF
--- a/.github/actions/run-open-code/action.yml
+++ b/.github/actions/run-open-code/action.yml
@@ -3,7 +3,7 @@ description: "Setup OpenCode, resolve LLM provider, and run opencode with retry"
 
 inputs:
   model_name:
-    description: "Model name (e.g. openrouter/openai/gpt-5-nano, vercel/anthropic/claude-sonnet-4)"
+    description: "Model name (e.g. openrouter/openai/gpt-5-nano, vercel/anthropic/claude-sonnet-4, rikyu/kimi-k3)"
     required: true
   prompt:
     description: "Prompt passed to opencode (ignored if prompt_file is provided)"
@@ -147,6 +147,15 @@ runs:
             # airas syncs the key under litellm's name; opencode reads
             # AI_GATEWAY_API_KEY. Accept either.
             echo "AI_GATEWAY_API_KEY=${AI_GATEWAY_API_KEY:-${VERCEL_AI_GATEWAY_API_KEY}}" >> "$GITHUB_ENV"
+            ;;
+
+          # RIKEN R-CCS's Rikyu API, declared as a custom OpenAI-compatible
+          # provider in .opencode/opencode.jsonc (which holds its base URL).
+          # The model after the prefix must be a key under that provider's
+          # "models".
+          rikyu/*)
+            echo "PROVIDER=rikyu" >> "$GITHUB_ENV"
+            echo "RIKYU_API_KEY=${RIKYU_API_KEY}" >> "$GITHUB_ENV"
             ;;
 
           openai/*)

--- a/.github/workflows/compile_latex.yml
+++ b/.github/workflows/compile_latex.yml
@@ -28,7 +28,7 @@ on:
           - open_code
         default: 'claude_code'
       model_name:
-        description: 'Model to use (for OpenCode: openrouter/openai/gpt-5-nano or vercel/anthropic/claude-sonnet-4, for Claude Code: sonnet/opus/haiku)'
+        description: 'Model to use (for OpenCode: openrouter/openai/gpt-5-nano, vercel/anthropic/claude-sonnet-4 or rikyu/kimi-k3, for Claude Code: sonnet/opus/haiku)'
         required: true
         default: 'sonnet'
       # NOTE: Use prompt_path instead of passing prompt directly to avoid
@@ -143,6 +143,7 @@ jobs:
 
           OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
           VERCEL_AI_GATEWAY_API_KEY: ${{ secrets.VERCEL_AI_GATEWAY_API_KEY }}
+          RIKYU_API_KEY: ${{ secrets.RIKYU_API_KEY }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           GOOGLE_API_KEY: ${{ secrets.GEMINI_API_KEY }}

--- a/.github/workflows/run_code_generator.yml
+++ b/.github/workflows/run_code_generator.yml
@@ -29,7 +29,7 @@ on:
           - open_code
         default: 'claude_code'
       model_name:
-        description: 'Model to use (for OpenCode: openrouter/openai/gpt-5-nano or vercel/anthropic/claude-sonnet-4, for Claude Code: sonnet/opus/haiku)'
+        description: 'Model to use (for OpenCode: openrouter/openai/gpt-5-nano, vercel/anthropic/claude-sonnet-4 or rikyu/kimi-k3, for Claude Code: sonnet/opus/haiku)'
         required: true
         default: 'sonnet'
       # NOTE: Use prompt_path instead of passing prompt directly to avoid
@@ -125,6 +125,7 @@ jobs:
 
           OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
           VERCEL_AI_GATEWAY_API_KEY: ${{ secrets.VERCEL_AI_GATEWAY_API_KEY }}
+          RIKYU_API_KEY: ${{ secrets.RIKYU_API_KEY }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           GOOGLE_API_KEY: ${{ secrets.GEMINI_API_KEY }}

--- a/.github/workflows/run_diagram_generator.yml
+++ b/.github/workflows/run_diagram_generator.yml
@@ -25,7 +25,7 @@ on:
           - open_code
         default: 'claude_code'
       model_name:
-        description: 'Model to use (for OpenCode: openrouter/openai/gpt-5-nano or vercel/anthropic/claude-sonnet-4, for Claude Code: sonnet/opus/haiku)'
+        description: 'Model to use (for OpenCode: openrouter/openai/gpt-5-nano, vercel/anthropic/claude-sonnet-4 or rikyu/kimi-k3, for Claude Code: sonnet/opus/haiku)'
         required: true
         default: 'sonnet'
       prompt_path:
@@ -124,6 +124,7 @@ jobs:
         env:
           OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
           VERCEL_AI_GATEWAY_API_KEY: ${{ secrets.VERCEL_AI_GATEWAY_API_KEY }}
+          RIKYU_API_KEY: ${{ secrets.RIKYU_API_KEY }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           GOOGLE_API_KEY: ${{ secrets.GEMINI_API_KEY }}

--- a/.github/workflows/run_experiment.yml
+++ b/.github/workflows/run_experiment.yml
@@ -57,6 +57,7 @@ jobs:
       OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
       OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
       VERCEL_AI_GATEWAY_API_KEY: ${{ secrets.VERCEL_AI_GATEWAY_API_KEY }}
+      RIKYU_API_KEY: ${{ secrets.RIKYU_API_KEY }}
       WANDB_API_KEY: ${{ secrets.WANDB_API_KEY }}
 
     steps:
@@ -153,6 +154,7 @@ jobs:
               -e OPENAI_API_KEY \
               -e OPENROUTER_API_KEY \
               -e VERCEL_AI_GATEWAY_API_KEY \
+              -e RIKYU_API_KEY \
               -e WANDB_API_KEY \
               airas-experiment:latest \
               bash -c '

--- a/.github/workflows/run_experiment_validator.yml
+++ b/.github/workflows/run_experiment_validator.yml
@@ -45,7 +45,7 @@ on:
           - open_code
         default: 'claude_code'
       model_name:
-        description: 'Model to use (for OpenCode: openrouter/openai/gpt-5-nano or vercel/anthropic/claude-sonnet-4, for Claude Code: sonnet/opus/haiku)'
+        description: 'Model to use (for OpenCode: openrouter/openai/gpt-5-nano, vercel/anthropic/claude-sonnet-4 or rikyu/kimi-k3, for Claude Code: sonnet/opus/haiku)'
         required: true
         default: 'sonnet'
       # NOTE: Use prompt_path instead of passing prompt directly to avoid
@@ -217,6 +217,7 @@ jobs:
 
           OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
           VERCEL_AI_GATEWAY_API_KEY: ${{ secrets.VERCEL_AI_GATEWAY_API_KEY }}
+          RIKYU_API_KEY: ${{ secrets.RIKYU_API_KEY }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           GOOGLE_API_KEY: ${{ secrets.GEMINI_API_KEY }}

--- a/.github/workflows/run_interactive_repo_agent.yml
+++ b/.github/workflows/run_interactive_repo_agent.yml
@@ -21,7 +21,7 @@ on:
           - open_code
         default: 'claude_code'
       model_name:
-        description: 'Model to use (for OpenCode: openrouter/openai/gpt-5-nano or vercel/anthropic/claude-sonnet-4, for Claude Code: sonnet/opus/haiku)'
+        description: 'Model to use (for OpenCode: openrouter/openai/gpt-5-nano, vercel/anthropic/claude-sonnet-4 or rikyu/kimi-k3, for Claude Code: sonnet/opus/haiku)'
         required: true
         default: 'sonnet'
       timeout_minutes:
@@ -118,6 +118,12 @@ jobs:
               echo "LLM_PROVIDER=vercel" >> "$GITHUB_ENV"
               echo "AI_GATEWAY_API_KEY=${{ secrets.VERCEL_AI_GATEWAY_API_KEY }}" >> "$GITHUB_ENV"
               ;;
+            # RIKEN R-CCS's Rikyu API, declared as a custom OpenAI-compatible
+            # provider in .opencode/opencode.jsonc (which holds its base URL).
+            rikyu/*)
+              echo "LLM_PROVIDER=rikyu" >> "$GITHUB_ENV"
+              echo "RIKYU_API_KEY=${{ secrets.RIKYU_API_KEY }}" >> "$GITHUB_ENV"
+              ;;
             openai/*)
               echo "LLM_PROVIDER=openai" >> "$GITHUB_ENV"
               echo "OPENAI_API_KEY=${{ secrets.OPENAI_API_KEY }}" >> "$GITHUB_ENV"
@@ -182,7 +188,7 @@ jobs:
           else
             # OpenCode: inject provider-specific env vars resolved in earlier step
             for VAR in OPENROUTER_API_KEY OPENAI_API_KEY ANTHROPIC_API_KEY GOOGLE_API_KEY \
-                       AI_GATEWAY_API_KEY \
+                       AI_GATEWAY_API_KEY RIKYU_API_KEY \
                        AZURE_OPENAI_API_KEY AZURE_OPENAI_ENDPOINT AZURE_OPENAI_API_VERSION \
                        AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY AWS_DEFAULT_REGION; do
               VAL="${!VAR}"

--- a/.github/workflows/run_verification_code_generator.yml
+++ b/.github/workflows/run_verification_code_generator.yml
@@ -33,7 +33,7 @@ on:
           - open_code
         default: 'claude_code'
       model_name:
-        description: 'Model to use (for OpenCode: openrouter/openai/gpt-5-nano or vercel/anthropic/claude-sonnet-4, for Claude Code: sonnet/opus/haiku)'
+        description: 'Model to use (for OpenCode: openrouter/openai/gpt-5-nano, vercel/anthropic/claude-sonnet-4 or rikyu/kimi-k3, for Claude Code: sonnet/opus/haiku)'
         required: true
         default: 'sonnet'
       prompt_path:
@@ -130,6 +130,7 @@ jobs:
 
           OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
           VERCEL_AI_GATEWAY_API_KEY: ${{ secrets.VERCEL_AI_GATEWAY_API_KEY }}
+          RIKYU_API_KEY: ${{ secrets.RIKYU_API_KEY }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           GOOGLE_API_KEY: ${{ secrets.GEMINI_API_KEY }}

--- a/.opencode/opencode.jsonc
+++ b/.opencode/opencode.jsonc
@@ -4,5 +4,27 @@
   "experimental": {
     "openTelemetry": true
   },
-  "plugin": ["opencode-plugin-langfuse"]  // https://github.com/omercnet/opencode-plugin-langfuse
+  "plugin": ["opencode-plugin-langfuse"],  // https://github.com/omercnet/opencode-plugin-langfuse
+  // RIKEN R-CCS's Rikyu API (OpenAI-compatible). The provider ID matches the
+  // prefix airas uses for the same endpoint, so one model name works in both
+  // layers: "rikyu/<model>". The key comes from a repository secret, injected
+  // by the workflows.
+  //
+  // Add one entry per model ID the endpoint reports at GET /v1/models — the
+  // key must be that exact ID, since it is what gets sent upstream.
+  "provider": {
+    "rikyu": {
+      "npm": "@ai-sdk/openai-compatible",
+      "name": "Rikyu (RIKEN R-CCS)",
+      "options": {
+        "baseURL": "https://api.rikyu.r-ccs.riken.jp/v1",
+        "apiKey": "{env:RIKYU_API_KEY}"
+      },
+      "models": {
+        "kimi-k3": {
+          "name": "Kimi K3"
+        }
+      }
+    }
+  }
 }


### PR DESCRIPTION
Part of airas-org/airas#969 — the runner half of airas-org/airas#971.

> **Note**: this replaces an earlier revision of this PR that used a generic `openai_compatible` provider. The issue's updated naming policy — specific name, generic implementation — is what is implemented here.

## What this does

Declares RIKEN R-CCS's Rikyu API (OpenAI-compatible) as a custom provider, so its models can drive the coding agent. The provider ID matches the prefix airas uses for the same endpoint, so `rikyu/<model>` names one thing in both layers — no per-layer translation to remember.

- **`.opencode/opencode.jsonc`** — provider backed by `@ai-sdk/openai-compatible`, with the published base URL and `apiKey` read from `RIKYU_API_KEY`. Register one entry under `models` per ID the endpoint reports at `GET /v1/models`; the key is what gets sent upstream, so it must match exactly.
- **`run-open-code` action** — resolves `rikyu/*` and exports `RIKYU_API_KEY`.
- **`run_interactive_repo_agent`** — same resolution in its inline case statement, and the key injected into the tmux session.
- **Workflows** — the key passed from repository secrets wherever OpenCode runs (`compile_latex`, `run_code_generator`, `run_diagram_generator`, `run_experiment_validator`, `run_verification_code_generator`, `run_interactive_repo_agent`) and into the experiment containers in `run_experiment`, whose research code may call an LLM. `model_name` input descriptions mention the new form.

The secret itself arrives from airas: airas-org/airas#971 adds `RIKYU_API_KEY` to the sync lists, so `set_github_actions_secrets` pushes it to each experiment repo.

## Verification

- All workflow and action YAML parses; the provider-resolution script passes `bash -n`, and running it directly resolves `rikyu/kimi-k3` to `PROVIDER=rikyu` + the key in `GITHUB_ENV`.
- `opencode.jsonc` still parses after the action's comment-stripping merge step, with the provider, its literal base URL and its model intact (the stripper's lookbehind spares `https://`).

Not verified: **a real run against the live endpoint**. The key is issued per project, must not land in a repo, and the host is unreachable from this environment. `kimi-k3` is the model ID assumed in the issue, not a confirmed one — replace it once `GET /v1/models` is checked. Coding-agent use also depends on the server serving tool calls (on vLLM, a tool-call parser must be enabled), which is the issue's first checklist item.