### PR TITLE
fix: align default execution mode with sanity/pilot/full

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -5,8 +5,8 @@ defaults:
   - _self_
   - run: ???  # loads from config/run/, accessible as 'run=' in CLI
 
-# Execution mode: main, sanity, or pilot
-mode: main
+# Execution mode: full, sanity, or pilot
+mode: full
 
 # Results output directory
 results_dir: .research/results


### PR DESCRIPTION
Fixes #25

## 変更内容

`config/config.yaml` の既定値を `mode: main` → `mode: full` に変更し、コメントも `# Execution mode: full, sanity, or pilot` に合わせました。

```diff
-# Execution mode: main, sanity, or pilot
-mode: main
+# Execution mode: full, sanity, or pilot
+mode: full
```

## 理由

`main` を使っていたのはリポジトリ内でこの 1 箇所だけで、他のすべての定義と食い違っていました。

| 場所 | 値 |
|---|---|
| `config/config.yaml`（変更前） | `main` |
| `AGENTS.md` | `sanity` / `pilot` / `full` |
| `.github/prompts/run_code_generator.md` | `sanity` / `pilot` / `full` |
| `.github/prompts/run_code_regenerator.md` | `mode=full` |
| airas `RunStage` enum | `SANITY` / `PILOT` / `FULL` |

実行時には必ず `sanity` / `pilot` / `full` が渡されるため実害は既定値のまま動かした場合に限られますが、コード生成エージェントがこのファイルのコメントを読んで `main` 用の分岐を書いてしまう問題がありました。

## 確認

- リポジトリ全体を再 grep し、`main` をモード値として参照している箇所が他にないことを確認（残る `main` はすべて `main.tex` / `src.main` などの無関係な一致）
- `yaml.safe_load` でパースが通り、`mode` が `full` になることを確認

---
_Generated by [Claude Code](https://claude.ai/code/session_01WsuGe3UHHU5DK86oChqGT9)_