### PR TITLE
fix: clone 直後に `uv sync` が通る最小限の pyproject.toml を同梱する

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,1 +1,17 @@
-# Please list the required python packages.
+# Please list the required python packages in `dependencies` below.
+# Keep this file limited to dependencies (hydra-core, wandb, plus
+# task-specific libraries) — see AGENTS.md.
+
+[project]
+name = "experiment"
+version = "0.1.0"
+requires-python = ">=3.11"
+dependencies = [
+    "hydra-core",
+    "wandb",
+]
+
+# `src/` is run with `uv run python -m src.main` from the repository root,
+# never installed as a distribution, so this project is not a package.
+[tool.uv]
+package = false


### PR DESCRIPTION
Closes #24

## 問題

`main` の `pyproject.toml` はコメント 1 行だけで `[project]` テーブルが無く、**空ではなく壊れた**プロジェクト定義でした。clone 直後に `uv sync` も `tomllib.load` も失敗するため、AGENTS.md の推奨ワークフローの手順 3（構文チェック）・4（`mode=sanity`）に到達する前に、エージェントが pyproject を一から書く想定外の作業が発生していました。

## 変更

`pyproject.toml` に最小限の有効な骨組みを追加しました。依存は AGENTS.md が既に定めている `hydra-core` / `wandb` の 2 つを初期値にしています。

```toml
[project]
name = "experiment"
version = "0.1.0"
requires-python = ">=3.11"
dependencies = [
    "hydra-core",
    "wandb",
]

[tool.uv]
package = false
```

### `[build-system]` ではなく `package = false` にした理由

Issue の提案では `hatchling` の `[build-system]` を入れる形でしたが、この構成では `uv sync` が通りません。

- `src/` は `uv run python -m src.main` でリポジトリ root から実行されるだけで、配布物としてインストールされることはない（`experiment` という名前のパッケージディレクトリも存在しない）
- `Dockerfile` は `pyproject.toml` と `uv.lock` だけを `COPY` した状態で `uv sync` を実行するので、ビルドバックエンドがあるとソースが無い時点でビルドに失敗する

そのため build backend は入れず、`[tool.uv] package = false` で非パッケージプロジェクトであることを明示しています。

`uv.lock` はコミットしていません。テンプレートから派生した各実験リポジトリでエージェントがタスク固有の依存を足す前提であり、`Dockerfile` も `uv sync --frozen || uv sync` とロックを任意扱いにしているためです。

## 動作確認

- `python3 -c "import tomllib; tomllib.load(open('pyproject.toml','rb'))"` → パース成功
- `uv sync` → hydra-core 1.3.5 / wandb 0.28.1 を含む 20 パッケージを解決・インストール
- `uv run python -m src.main` → 実行成功（`src/main.py` は空のまま、モジュール解決が通ることの確認）

なお `src/*.py` が 0 バイトなのはエージェントが書く設計として意図されたものなので、Issue の記載どおりそのままにしています。


---
_Generated by [Claude Code](https://claude.ai/code/session_01Q4zZpe2MfyNUoJ8482PxMY)_