### PR TITLE
fix(ci): 画像準備ワークフローで図のディレクトリ構造を保持する

### DIFF
--- a/.github/workflows/prepare_images_for_html.yml
+++ b/.github/workflows/prepare_images_for_html.yml
@@ -42,22 +42,26 @@ jobs:
 
           echo "Looking for PDFs in:$SEARCH_DIRS ..."
 
-          find $SEARCH_DIRS -type f -name "*.pdf" | while read pdf; do
-            name=$(basename "$pdf" .pdf)
-            echo "Converting $pdf to PNG..."
-            pdftoppm "$pdf" "$tmp_dir/${name}" -png
+          # Each PDF is converted in place under its own relative path so that
+          # same-named figures from different runs (e.g. results/run-1/accuracy.pdf
+          # and results/run-2/accuracy.pdf) do not overwrite each other.
+          for dir in $SEARCH_DIRS; do
+            find "$dir" -type f -name "*.pdf" -print0 | while IFS= read -r -d '' pdf; do
+              rel="${pdf#"$dir"/}"
+              out="$tmp_dir/${rel%.pdf}"
+              mkdir -p "$(dirname "$out")"
+              echo "Converting $pdf to PNG..."
+              pdftoppm "$pdf" "$out" -png
+            done
           done
 
-          if ls "$tmp_dir"/*-1.png 1> /dev/null 2>&1; then
-            for png in "$tmp_dir"/*-1.png; do
-              base=$(basename "$png" -1.png)
-              mv "$png" "$tmp_dir/${base}.png"
-            done
-          fi
+          find "$tmp_dir" -type f -name "*-1.png" -print0 | while IFS= read -r -d '' png; do
+            mv "$png" "${png%-1.png}.png"
+          done
 
       - name: Copy converted PNGs to gh-pages branch
         run: |
-          if [ -z "$(ls -A /tmp/output_images/*.png 2>/dev/null)" ]; then
+          if [ -z "$(find /tmp/output_images -type f -name '*.png' -print -quit 2>/dev/null)" ]; then
             echo "No PNG images were generated."
             exit 0
           fi
@@ -67,7 +71,7 @@ jobs:
 
           target_dir="branches/${{ github.ref_name }}/images"
           mkdir -p "$target_dir"
-          cp /tmp/output_images/*.png "$target_dir"
+          rsync -am --include='*/' --include='*.png' --exclude='*' /tmp/output_images/ "$target_dir/"
 
       - name: Commit and push to gh-pages
         run: |

--- a/.github/workflows/prepare_images_for_latex.yml
+++ b/.github/workflows/prepare_images_for_latex.yml
@@ -33,8 +33,14 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
 
+      # Figures keep their directory structure below each source directory, so
+      # LaTeX references them as images/<relative path>. This matches how
+      # compile_latex.yml materializes figures; a flat copy would silently
+      # overwrite same-named figures from different runs
+      # (e.g. results/run-1/accuracy.pdf vs results/run-2/accuracy.pdf).
       - name: Copy experiment images to LaTeX directory
         run: |
+          set -e
           echo "Using source directories: $SOURCE_DIR, $DIAGRAMS_DIR"
           echo "Target directory: $TARGET_IMG_DIR"
 
@@ -58,11 +64,12 @@ jobs:
 
           echo "Copying PDF images from$SEARCH_DIRS to $TARGET_IMG_DIR"
 
-          find $SEARCH_DIRS -type f -name "*.pdf" \
-            -exec cp {} "$TARGET_IMG_DIR/" \;
+          for dir in $SEARCH_DIRS; do
+            rsync -am --include='*/' --include='*.pdf' --exclude='*' "$dir/" "$TARGET_IMG_DIR/"
+          done
 
           echo "Image copy completed. Files in images/:"
-          ls -la "$TARGET_IMG_DIR/" || echo "No images present."
+          find "$TARGET_IMG_DIR" -type f | sort || echo "No images present."
 
       - name: Commit and push changes
         run: |


### PR DESCRIPTION
Closes #27

## 問題

`prepare_images_for_latex.yml` と `prepare_images_for_html.yml` が図を平坦化していました。

- `prepare_images_for_latex.yml`: `find ... -exec cp {} "$TARGET_IMG_DIR/" \;` の宛先がディレクトリ 1 つなので、ディレクトリ構造が失われます。
- `prepare_images_for_html.yml`: 変換先が平坦な `/tmp/output_images` で、そこから `cp /tmp/output_images/*.png "$target_dir"` していました。

いずれも同名ファイルがエラーにも警告にもならずに黙って上書きされ、比較実験の図が片方だけ消えます。

```
.research/results/run-1/accuracy.pdf  ─┐
                                       ├─→ images/accuracy.pdf （どちらか一方だけ残る）
.research/results/run-2/accuracy.pdf  ─┘
```

`compile_latex.yml` は #15 で既に構造保存に修正済みで、平坦化のワークフローだけが古い規約のまま残っていました。手で dispatch すると、構造保存でコピーされた `images/` に平坦なコピーが混ざります。

## 変更内容

issue で提案されたとおり、削除ではなく `compile_latex.yml` と同じ `rsync` に揃えて構造保存に統一しました。ワークフロー名で外部から dispatch される可能性があるため、非破壊な方を選んでいます。

**`prepare_images_for_latex.yml`**

`find`/`cp` を `compile_latex.yml` と同一の `rsync` に置き換え：

```bash
for dir in $SEARCH_DIRS; do
  rsync -am --include='*/' --include='*.pdf' --exclude='*' "$dir/" "$TARGET_IMG_DIR/"
done
```

あわせて、コピー先の一覧表示を `ls -la` から再帰的な `find ... | sort`（`compile_latex.yml` と同じ形）に変更し、規約を説明するコメントを追加しました。

**`prepare_images_for_html.yml`**

- 各 PDF をソースディレクトリからの相対パスの位置で変換するようにし、PNG のツリーがソースのツリーを反映するようにしました。
- gh-pages へのコピーを `cp *.png` から同じ `rsync`（`--include='*.png'`）に変更。
- 「PNG が生成されたか」の判定と `-1.png` ページサフィックスのリネームを、平坦な glob から再帰的な `find -print0` に変更。ファイル名の空白等も安全に扱えます。

いずれも `.research/results` / `.research/diagrams` それぞれの直下からの相対パスを保持するので、`compile_latex.yml` および airas 側（`open_in_overleaf` / `collect_latex_project_files.py` など）の規約と一致します。LaTeX からは従来どおり `images/<相対パス>` で参照できます。

## 動作確認

- 両ファイルの YAML パースを確認。
- `run-1/accuracy.pdf`、`run-2/accuracy.pdf`、`arch/overview.pdf` を含むフィクスチャで HTML 側の変換ループを実行し、`run-1/accuracy.png` / `run-2/accuracy.png` / `arch/overview.png` の 3 つが構造を保ったまま生成されること（＝同名ファイルが消えないこと）を確認しました。空ディレクトリでの「PNG なし」判定も確認済みです。
- `rsync` はこの検証環境に入っておらずローカル実行はできていませんが、`compile_latex.yml` が同じ runner イメージ上で既に使用している同一のコマンド形です（ubuntu-latest にプリインストール）。

---
_Generated by [Claude Code](https://claude.ai/code/session_013AS6XWXUMu15JA3bSFmBEJ)_